### PR TITLE
Company를 따로 삭제할 수 있게 Delete코드 추가

### DIFF
--- a/src/main/java/com/kbe5/rento/domain/company/controller/CompanyController.java
+++ b/src/main/java/com/kbe5/rento/domain/company/controller/CompanyController.java
@@ -44,4 +44,9 @@ public class CompanyController {
     public ResponseEntity<Boolean> checkAvailableBizNumber(@PathVariable int bizNumber) {
         return ResponseEntity.ok(!companyService.isExistsBizNumber(bizNumber));
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<CompanyDeleteResponse> companyDelete(@PathVariable Long id) {
+        return ResponseEntity.ok(companyService.delete(id));
+    }
 }

--- a/src/main/java/com/kbe5/rento/domain/company/dto/response/CompanyDeleteResponse.java
+++ b/src/main/java/com/kbe5/rento/domain/company/dto/response/CompanyDeleteResponse.java
@@ -2,7 +2,7 @@ package com.kbe5.rento.domain.company.dto.response;
 
 public record CompanyDeleteResponse(
         Long id,
-        Boolean isSuccess
+        boolean isSuccess
 ) {
     public static CompanyDeleteResponse from(Long id, boolean result) {
        return new CompanyDeleteResponse(id, result);

--- a/src/main/java/com/kbe5/rento/domain/company/dto/response/CompanyDeleteResponse.java
+++ b/src/main/java/com/kbe5/rento/domain/company/dto/response/CompanyDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.kbe5.rento.domain.company.dto.response;
+
+public record CompanyDeleteResponse(
+        Long id,
+        Boolean isSuccess
+) {
+    public static CompanyDeleteResponse from(Long id, boolean result) {
+       return new CompanyDeleteResponse(id, result);
+    }
+}

--- a/src/main/java/com/kbe5/rento/domain/company/service/CompanyService.java
+++ b/src/main/java/com/kbe5/rento/domain/company/service/CompanyService.java
@@ -8,6 +8,7 @@ import com.kbe5.rento.domain.company.dto.response.*;
 import com.kbe5.rento.domain.company.entity.Company;
 import com.kbe5.rento.domain.company.repository.CompanyRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,8 +63,13 @@ public class CompanyService {
         return CompanyUpdateResponse.from(company);
     }
 
-    public void delete(Company company) {
-        companyRepository.delete(company);
+    public CompanyDeleteResponse delete(Long id) {
+        Company company = companyRepository.findById(id)
+                .orElseThrow(() -> new DomainException(ErrorType.NO_SEARCH_RESULTS));
+
+        companyRepository.delete(company); // 에러 방식 수정 후 리펙토링 예정입니다.
+
+        return new CompanyDeleteResponse(company.getId(), true);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/kbe5/rento/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/kbe5/rento/domain/manager/service/ManagerService.java
@@ -88,10 +88,6 @@ public class ManagerService {
 
         managerRepository.delete(manager);
 
-        if (!managerRepository.existsByCompanyId(manager.getCompanyId())) {
-            companyService.delete(manager.getCompanyId());
-        }
-
         return new ManagerDeleteResponse(true);
     }
 


### PR DESCRIPTION
Company를 따로 삭제할 수 있게 Delete코드 추가

- resolves #17 

---

### 🚀 어떤 기능을 구현했나요 ?
- Company를 따로 삭제할 수 있게 Delete코드 추가하고, 기존에 Manager삭제 시 Company도 삭제되는 로직을 삭제했습니다.
