### PR TITLE
[BE] Device 등록 리팩토링

### DIFF
--- a/src/main/java/com/kbe5/rento/common/exception/DeviceException.java
+++ b/src/main/java/com/kbe5/rento/common/exception/DeviceException.java
@@ -1,0 +1,14 @@
+package com.kbe5.rento.common.exception;
+
+import com.kbe5.rento.domain.device.enums.DeviceResultCode;
+import lombok.Getter;
+
+@Getter
+public class DeviceException extends RuntimeException{
+    private final String resultCode;
+    private final String resultMessage;
+    public DeviceException(DeviceResultCode deviceResultCode) {
+        this.resultCode = deviceResultCode.getCode();
+        this.resultMessage = deviceResultCode.getMessage();
+    }
+}

--- a/src/main/java/com/kbe5/rento/common/exception/DeviceExceptionResponse.java
+++ b/src/main/java/com/kbe5/rento/common/exception/DeviceExceptionResponse.java
@@ -1,0 +1,11 @@
+package com.kbe5.rento.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record DeviceExceptionResponse(
+    @JsonProperty("rstCd")
+    String resultCode,
+    @JsonProperty("rstMsg")
+    String message
+) {
+}

--- a/src/main/java/com/kbe5/rento/common/exception/ExceptionController.java
+++ b/src/main/java/com/kbe5/rento/common/exception/ExceptionController.java
@@ -3,29 +3,26 @@ package com.kbe5.rento.common.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @Slf4j
 @RestControllerAdvice
 public class ExceptionController {
+
     @ExceptionHandler(DomainException.class)
     public ResponseEntity<ExceptionResponse> customExceptionHandler(DomainException e) {
         log.warn("DomainException code: {}, message: {}", e.getStatus(), e.getMessage());
         return ResponseEntity.status(e.getStatus())
-                .body(e.toResponse());
+            .body(e.toResponse());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> exceptionHandler(Exception e) {
         log.error("[UnhandledException] {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ExceptionResponse(e.getMessage()));
+            .body(new ExceptionResponse(e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -34,5 +31,11 @@ public class ExceptionController {
 
         return ResponseEntity.badRequest().body(new ExceptionResponse(ErrorType.VALIDATION_ERROR.getMessage()));
 
+    }
+
+    @ExceptionHandler(DeviceException.class)
+    public ResponseEntity<DeviceExceptionResponse> deviceExceptionHandler(DeviceException e) {
+        log.warn("DeviceException code: {}, message: {}", e.getResultCode(), e.getResultMessage());
+        return ResponseEntity.ok(new DeviceExceptionResponse(e.getResultCode(), e.getResultMessage()));
     }
 }

--- a/src/main/java/com/kbe5/rento/domain/device/controller/DeviceController.java
+++ b/src/main/java/com/kbe5/rento/domain/device/controller/DeviceController.java
@@ -2,15 +2,13 @@ package com.kbe5.rento.domain.device.controller;
 
 import com.kbe5.rento.domain.device.dto.request.DeviceRegisterRequest;
 import com.kbe5.rento.domain.device.dto.request.OnEventRequest;
+import com.kbe5.rento.domain.device.dto.resonse.DeviceRegisterResponse;
 import com.kbe5.rento.domain.device.dto.resonse.OnEventResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 public interface DeviceController {
 
-    void registerDevice(DeviceRegisterRequest request);
+    ResponseEntity<DeviceRegisterResponse> registerDevice(DeviceRegisterRequest request);
 
     ResponseEntity<OnEventResponse> onEvent(OnEventRequest request);
 

--- a/src/main/java/com/kbe5/rento/domain/device/controller/DeviceControllerImpl.java
+++ b/src/main/java/com/kbe5/rento/domain/device/controller/DeviceControllerImpl.java
@@ -1,8 +1,11 @@
 package com.kbe5.rento.domain.device.controller;
 
+import com.kbe5.rento.domain.device.enums.DeviceResultCode;
 import com.kbe5.rento.domain.device.dto.request.OnEventRequest;
 import com.kbe5.rento.domain.device.dto.request.DeviceRegisterRequest;
+import com.kbe5.rento.domain.device.dto.resonse.DeviceRegisterResponse;
 import com.kbe5.rento.domain.device.dto.resonse.OnEventResponse;
+import com.kbe5.rento.domain.device.entity.Device;
 import com.kbe5.rento.domain.device.service.DeviceEventService;
 import com.kbe5.rento.domain.device.service.DeviceService;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +27,16 @@ public class DeviceControllerImpl implements DeviceController{
     private final DeviceEventService deviceEventService;
 
     @PostMapping
-    public void registerDevice(@RequestBody @Validated DeviceRegisterRequest request) {
-        deviceService.registerDevice(request);
+    public ResponseEntity<DeviceRegisterResponse> registerDevice(
+        @RequestBody @Validated DeviceRegisterRequest request) {
+
+        Device device = request.toDevice();
+
+        Device registerDevice = deviceService.registerDevice(device);
+
+        DeviceRegisterResponse response = DeviceRegisterResponse.of(DeviceResultCode.SUCCESS, registerDevice);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/on")

--- a/src/main/java/com/kbe5/rento/domain/device/dto/request/DeviceRegisterRequest.java
+++ b/src/main/java/com/kbe5/rento/domain/device/dto/request/DeviceRegisterRequest.java
@@ -1,6 +1,7 @@
 package com.kbe5.rento.domain.device.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kbe5.rento.domain.device.entity.Device;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -9,27 +10,35 @@ import jakarta.validation.constraints.NotNull;
 public record DeviceRegisterRequest(
     @JsonProperty("mdn")
     @NotNull(message = "{device.mdn.notnull}")
-    Long mobileDeviceNumber, //차량 번호
+    Long mdn,// 차량 번호
 
     @JsonProperty("tid")
     @NotBlank(message = "{device.tid.notblank}")
-    String terminalId, // A001로 고정
+    String terminalId, // A001 고정
 
     @JsonProperty("mid")
     @NotNull(message = "{device.mid.notnull}")
-    Integer makerId, // 6으로 고정
+    Integer makerId, // 6 고정
 
-    @Min(0)
-    @Max(65535)
     @JsonProperty("pv")
     @NotNull(message = "{device.pv.notnull}")
-    Integer packetVersion, // 5로 고정
+    @Min(value = 0, message = "{device.pv.min}")
+    @Max(value = 65535, message = "{device.pv.max}")
+    Integer packetVersion, // 5 고정
 
     @JsonProperty("did")
     @NotNull(message = "{device.did.notnull}")
     Integer deviceId
+){
 
-) {
-
-
+    public Device toDevice() {
+        return Device.builder()
+            .mdn(this.mdn())
+            .terminalId(this.terminalId())
+            .makerId(this.makerId())
+            .packetVersion(this.packetVersion())
+            .deviceId(this.deviceId())
+            .deviceFirmWareVersion("LTE 1.2")
+            .build();
+    }
 }

--- a/src/main/java/com/kbe5/rento/domain/device/dto/resonse/DeviceRegisterResponse.java
+++ b/src/main/java/com/kbe5/rento/domain/device/dto/resonse/DeviceRegisterResponse.java
@@ -1,0 +1,21 @@
+package com.kbe5.rento.domain.device.dto.resonse;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kbe5.rento.domain.device.enums.DeviceResultCode;
+import com.kbe5.rento.domain.device.entity.Device;
+
+public record DeviceRegisterResponse(
+    @JsonProperty("rstCd")
+    String resultCode,
+
+    @JsonProperty("rstMsg")
+    String resultMessage,
+
+    @JsonProperty("mdn")
+    Long mdn
+){
+
+    public static DeviceRegisterResponse of(DeviceResultCode resultCode, Device device) {
+        return new DeviceRegisterResponse(resultCode.getCode(), resultCode.getMessage(), device.getMdn());
+    }
+}

--- a/src/main/java/com/kbe5/rento/domain/device/entity/Device.java
+++ b/src/main/java/com/kbe5/rento/domain/device/entity/Device.java
@@ -1,7 +1,6 @@
 package com.kbe5.rento.domain.device.entity;
 
 import com.kbe5.rento.common.util.BaseEntity;
-import com.kbe5.rento.domain.device.dto.request.DeviceRegisterRequest;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -10,14 +9,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@Getter
 @Slf4j
+@Getter
 @Entity
 @Table(name = "devices")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Device extends BaseEntity {
 
-    private Long mobileDeviceNumber;
+    private Long mdn;
 
     private String terminalId;
 
@@ -30,24 +29,13 @@ public class Device extends BaseEntity {
     private String deviceFirmWareVersion;
 
     @Builder
-    public Device(Long mobileDeviceNumber, String terminalId, Integer makerId, Integer packetVersion,
+    public Device(Long mdn, String terminalId, Integer makerId, Integer packetVersion,
         Integer deviceId, String deviceFirmWareVersion) {
-        this.mobileDeviceNumber = mobileDeviceNumber;
+        this.mdn = mdn;
         this.terminalId = terminalId;
         this.makerId = makerId;
         this.packetVersion = packetVersion;
         this.deviceId = deviceId;
         this.deviceFirmWareVersion = deviceFirmWareVersion;
-    }
-
-    public static Device from(DeviceRegisterRequest request) {
-        return Device.builder()
-            .mobileDeviceNumber(request.mobileDeviceNumber())
-            .terminalId(request.terminalId())
-            .makerId(request.makerId())
-            .packetVersion(request.packetVersion())
-            .deviceId(request.deviceId())
-            .deviceFirmWareVersion("LTE 1.2")
-            .build();
     }
 }

--- a/src/main/java/com/kbe5/rento/domain/device/entity/event/OnOffEvent.java
+++ b/src/main/java/com/kbe5/rento/domain/device/entity/event/OnOffEvent.java
@@ -1,8 +1,6 @@
 package com.kbe5.rento.domain.device.entity.event;
 
-import com.kbe5.rento.common.datetime.DateUtil;
 import com.kbe5.rento.domain.device.dto.request.OnEventRequest;
-import com.kbe5.rento.domain.device.enums.EventType;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import java.time.LocalDateTime;
@@ -12,8 +10,9 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
-@Getter
+
 @Slf4j
+@Getter
 @Entity
 @SuperBuilder
 @DiscriminatorValue("ON_OFF")

--- a/src/main/java/com/kbe5/rento/domain/device/enums/DeviceResultCode.java
+++ b/src/main/java/com/kbe5/rento/domain/device/enums/DeviceResultCode.java
@@ -1,0 +1,37 @@
+package com.kbe5.rento.domain.device.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum DeviceResultCode {
+    SUCCESS("000", "Success"),
+    INVALID_ACCESS_PATH("100", "Invalid access path."),
+    WRONG_APPROACH("101", "This is the wrong approach."),
+    CONTENT_TYPE_ERROR("102", "Content-Type error."),
+    CONTENT_LENGTH_ERROR("103", "Content-Length error."),
+    ACCEPT_ERROR("104", "ACCEPT error."),
+    CACHE_CONTROL_ERROR("105", "Cache-Control error."),
+    ACCEPT_ENCODING_ERROR("106", "Accept-Encoding error."),
+    TIMESTAMP_ERROR("107", "Timestamp error."),
+    TUID_ERROR("108", "TUID error."),
+    MISSING_KEY_VERSION("109", "Missing Key-Version."),
+    NOT_JSON_HEADER("110", "Not json header type."),
+    MISSING_TOKEN("200", "Missing Token."),
+    INVALID_TOKEN("201", "Invalid Token."),
+    UNUSABLE_TOKEN("202", "Unusable Token."),
+    PROTOCOL_FORMAT_ERROR("300", "This is a protocol format error."),
+    REQUIRED_PARAMETER_ERROR("301", "Required parameter error."),
+    NO_SEARCH_RESULTS("302", "There are no search results."),
+    DECRYPTION_ERROR("303", "Decryption error."),
+    MISMATCHED_MDN("304", "Mismatched MDN."),
+    DATA_PROCESSING_ERROR("400", "An error occurred while processing data."),
+    UNDEFINED_ERROR("500", "An undefined error has occurred.");
+
+    private final String code;
+    private final String message;
+
+    DeviceResultCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/kbe5/rento/domain/device/repository/DeviceRepository.java
+++ b/src/main/java/com/kbe5/rento/domain/device/repository/DeviceRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DeviceRepository extends JpaRepository<Device, Long> {
 
-    Optional<Device> findByMobileDeviceNumber(Long mobileDeviceNumber);
+    Optional<Device> findByMdn(Long mdn);
 }

--- a/src/main/java/com/kbe5/rento/domain/device/service/DeviceService.java
+++ b/src/main/java/com/kbe5/rento/domain/device/service/DeviceService.java
@@ -1,7 +1,8 @@
 package com.kbe5.rento.domain.device.service;
 
-import com.kbe5.rento.domain.device.dto.request.DeviceRegisterRequest;
+import com.kbe5.rento.domain.device.enums.DeviceResultCode;
 import com.kbe5.rento.domain.device.entity.Device;
+import com.kbe5.rento.common.exception.DeviceException;
 import com.kbe5.rento.domain.device.repository.DeviceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,18 +18,17 @@ public class DeviceService {
     private final DeviceRepository deviceRepository;
 
     @Transactional
-    public void registerDevice(DeviceRegisterRequest request) {
+    public Device registerDevice(Device device) {
 
-        validateDuplicateDevice(request);
+        validateDuplicateDevice(device.getMdn());
 
-        deviceRepository.save(Device.from(request));
+        return deviceRepository.save(device);
     }
 
-    private void validateDuplicateDevice(DeviceRegisterRequest request) {
-        deviceRepository.findByMobileDeviceNumber(request.mobileDeviceNumber())
+    private void validateDuplicateDevice(Long mdn) {
+        deviceRepository.findByMdn(mdn)
             .ifPresent(device -> {
-                throw new IllegalArgumentException("이미 등록된 디바이스입니다.");
+                throw new DeviceException(DeviceResultCode.MISMATCHED_MDN);
             });
     }
-
 }

--- a/src/test/java/com/kbe5/rento/domain/device/service/DeviceServiceTest.java
+++ b/src/test/java/com/kbe5/rento/domain/device/service/DeviceServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.kbe5.rento.domain.device.dto.request.DeviceRegisterRequest;
 import com.kbe5.rento.domain.device.entity.Device;
+import com.kbe5.rento.common.exception.DeviceException;
 import com.kbe5.rento.domain.device.repository.DeviceRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -32,20 +33,22 @@ class DeviceServiceTest {
     void registerDevice() {
 
         //given
-        DeviceRegisterRequest deviceRegisterRequest = new DeviceRegisterRequest(
-            1L,
-            "A001",
-            6,
-            5,
-            1
+        DeviceRegisterRequest request = new DeviceRegisterRequest(
+            1L,        // mdn
+            "A001",    // terminalId
+            6,         // makerId
+            5,         // packetVersion
+            1          // deviceId
         );
 
         //stub
-        when(deviceRepository.findByMobileDeviceNumber(deviceRegisterRequest.mobileDeviceNumber()))
+        when(deviceRepository.findByMdn(request.mdn()))
             .thenReturn(Optional.empty());
 
         // when
-        deviceService.registerDevice(deviceRegisterRequest);
+        Device device = request.toDevice();
+
+        deviceService.registerDevice(device);
 
         // then
         verify(deviceRepository).save(any(Device.class));
@@ -56,22 +59,23 @@ class DeviceServiceTest {
     void registerDeviceFail() {
 
         //given
-        DeviceRegisterRequest deviceRegisterRequest = new DeviceRegisterRequest(
-            1L,
-            "A001",
-            6,
-            5,
-            1
+        DeviceRegisterRequest request = new DeviceRegisterRequest(
+            1L,        // mdn
+            "A001",    // terminalId
+            6,         // makerId
+            5,         // packetVersion
+            1          // deviceId
         );
 
         //stub
-        when(deviceRepository.findByMobileDeviceNumber(deviceRegisterRequest.mobileDeviceNumber()))
+        when(deviceRepository.findByMdn(request.mdn()))
             .thenReturn(Optional.of(mock(Device.class)));
 
         //when
-        assertThatThrownBy(() -> deviceService.registerDevice(deviceRegisterRequest))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("이미 등록된 디바이스입니다.");
+        Device device = request.toDevice();
+
+        assertThatThrownBy(() -> deviceService.registerDevice(device))
+            .isInstanceOf(DeviceException.class);
 
         //then
         verify(deviceRepository, never()).save(any(Device.class));


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves # 35

---

### 🚀 어떤 기능을 구현했나요 ?
- enum 패키지에 DeviceResultCode 추가
- exception 추가
    - DeviceException
    - DeviceExceptionResponse
    - ExceptionController 에 deviceExceptionHandler 메서드 추가
    - validateDuplicateDevice 에서 DeviceExceptionResponse 처리로 변경
- registerDevice 컨트롤러 메서드에서 dto 엔티티 변환로직 작성
- DeviceService 에서는 Device 엔티티를 통해 작업하고 반환하는 로직으로 변경


### 🔥 어떤 문제를 마주했나요 ?
- 연동규격서에서 resonse 데이터에 반드시 필요로 하는 값이 존재하는데 이걸 flat 한형태로 보여주려면 ApiResponse 의 data 필드로는 해결할 수 없는 문제가 발생하였습니다.

### ✨ 어떻게 해결했나요 ?
- 현재는 dto 마다 구현을 하는 방식으로 해결하고 ApiResponse 는 연동규격서와 관련된 device 도메인에서는 사용하지 않을 생각입니다.
- 추후 ApiResponse 를 직렬화 하는과정에서 플랫하게 만들 수 있다고 하는데 중간 발표가 끝나고 도입해 보겠습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 예외처리 관련 코드, 컨트롤러에서 dto <-> entity 변환

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
