### PR TITLE
Geofence CRUD 구현

### DIFF
--- a/src/main/java/com/kbe5/rento/common/exception/ErrorType.java
+++ b/src/main/java/com/kbe5/rento/common/exception/ErrorType.java
@@ -34,13 +34,15 @@ public enum ErrorType {
     FAILED_LOGIN(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     // VEHICLE
-    SAME_VIHICLE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 차량 번호입니다."),
+    SAME_VEHICLE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 차량 번호입니다."),
     VEHICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "차량을 찾을 수 없습니다"),
 
     // Drive
     DRIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "운행을 찾지 못했습니다."),
-    USER_VEHICLE_COMPANY_MISMATCH(HttpStatus.BAD_REQUEST, "업체가 일치하지 않습니다");
+    USER_VEHICLE_COMPANY_MISMATCH(HttpStatus.BAD_REQUEST, "업체가 일치하지 않습니다"),
 
+    // Geofence
+    GEOFENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "지오펜스를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/kbe5/rento/domain/geofence/controller/GeofenceController.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/controller/GeofenceController.java
@@ -1,0 +1,21 @@
+package com.kbe5.rento.domain.geofence.controller;
+
+import com.kbe5.rento.common.apiresponse.ApiResponse;
+import com.kbe5.rento.domain.geofence.dto.request.GeofenceRegisterRequest;
+import com.kbe5.rento.domain.geofence.dto.request.GeofenceUpdateRequest;
+import com.kbe5.rento.domain.geofence.dto.response.GeofenceInfoResponse;
+import org.springframework.http.ResponseEntity;
+import java.util.List;
+
+public interface GeofenceController {
+
+    public ResponseEntity<ApiResponse<Void>> register(GeofenceRegisterRequest request);
+
+    public ResponseEntity<ApiResponse<List<GeofenceInfoResponse>>> getList(String companyCode);
+
+    public ResponseEntity<ApiResponse<GeofenceInfoResponse>> getDetail(Long id);
+
+    public ResponseEntity<ApiResponse<Void>> delete(Long id);
+
+    public ResponseEntity<ApiResponse<Void>> update(Long id, GeofenceUpdateRequest request);
+}

--- a/src/main/java/com/kbe5/rento/domain/geofence/controller/GeofenceControllerImpl.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/controller/GeofenceControllerImpl.java
@@ -59,8 +59,7 @@ public class GeofenceControllerImpl implements GeofenceController{
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> update(@PathVariable Long id,
                                                     @RequestBody @Valid GeofenceUpdateRequest request) {
-        Geofence updatedGeofence = GeofenceUpdateRequest.toEntity(request);
-        geofenceService.update(id, updatedGeofence);
+        geofenceService.update(id, request);
 
         return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, null);
     }

--- a/src/main/java/com/kbe5/rento/domain/geofence/controller/GeofenceControllerImpl.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/controller/GeofenceControllerImpl.java
@@ -1,0 +1,67 @@
+package com.kbe5.rento.domain.geofence.controller;
+
+import com.kbe5.rento.common.apiresponse.ApiResponse;
+import com.kbe5.rento.common.apiresponse.ApiResultCode;
+import com.kbe5.rento.common.apiresponse.ResEntityFactory;
+import com.kbe5.rento.domain.geofence.dto.request.GeofenceRegisterRequest;
+import com.kbe5.rento.domain.geofence.dto.request.GeofenceUpdateRequest;
+import com.kbe5.rento.domain.geofence.dto.response.GeofenceInfoResponse;
+import com.kbe5.rento.domain.geofence.entity.Geofence;
+import com.kbe5.rento.domain.geofence.service.GeofenceService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/geofence")
+public class GeofenceControllerImpl implements GeofenceController{
+
+    private final GeofenceService geofenceService;
+
+    @Override
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<Void>> register(@RequestBody @Valid
+                                                          GeofenceRegisterRequest request) {
+        Geofence geofence = GeofenceRegisterRequest.toEntity(request);
+        geofenceService.register(geofence);
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, null);
+    }
+
+    @Override
+    @GetMapping("/get-list/{companyCode}")
+    public ResponseEntity<ApiResponse<List<GeofenceInfoResponse>>> getList(@PathVariable String companyCode) {
+        List<Geofence> geofenceList = geofenceService.getGeofenceList(companyCode);
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, GeofenceInfoResponse.fromEntity(geofenceList));
+    }
+
+    @Override
+    @GetMapping("/get-detail/{id}")
+    public ResponseEntity<ApiResponse<GeofenceInfoResponse>> getDetail(@PathVariable Long id) {
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS,
+                GeofenceInfoResponse.fromEntity(geofenceService.getGeofenceDetail(id)));
+    }
+
+    @Override
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
+        geofenceService.delete(id);
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, null);
+    }
+
+    @Override
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> update(@PathVariable Long id,
+                                                    @RequestBody @Valid GeofenceUpdateRequest request) {
+        Geofence updatedGeofence = GeofenceUpdateRequest.toEntity(request);
+        geofenceService.update(id, updatedGeofence);
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, null);
+    }
+}

--- a/src/main/java/com/kbe5/rento/domain/geofence/controller/GeofenceControllerImpl.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/controller/GeofenceControllerImpl.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/geofence")
+@RequestMapping("/api/geofences")
 public class GeofenceControllerImpl implements GeofenceController{
 
     private final GeofenceService geofenceService;

--- a/src/main/java/com/kbe5/rento/domain/geofence/dto/request/GeofenceRegisterRequest.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/dto/request/GeofenceRegisterRequest.java
@@ -1,0 +1,37 @@
+package com.kbe5.rento.domain.geofence.dto.request;
+
+import com.kbe5.rento.domain.geofence.entity.Geofence;
+import com.kbe5.rento.domain.geofence.enums.EventType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record GeofenceRegisterRequest(
+        @NotBlank
+        String companyCode,
+
+        @NotBlank
+        String name,
+
+        @NotNull
+        long latitude,
+
+        @NotBlank
+        long longitude,
+
+        @NotNull
+        int radius,
+        String description
+) {
+    public static Geofence toEntity(GeofenceRegisterRequest request) {
+        return Geofence.builder()
+                .companyCode(request.companyCode)
+                .name(request.name)
+                .latitude(request.latitude)
+                .longitude(request.longitude)
+                .radius(request.radius)
+                .eventType(EventType.OFF)
+                .description(request.description)
+                .isActive(false)
+                .build();
+    }
+}

--- a/src/main/java/com/kbe5/rento/domain/geofence/dto/request/GeofenceUpdateRequest.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/dto/request/GeofenceUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.kbe5.rento.domain.geofence.dto.request;
+
+import com.kbe5.rento.domain.geofence.entity.Geofence;
+import com.kbe5.rento.domain.geofence.enums.EventType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record GeofenceUpdateRequest(
+        @NotBlank
+        String companyCode,
+
+        @NotBlank
+        String name,
+
+        @NotNull
+        long latitude,
+
+        @NotBlank
+        long longitude,
+
+        @NotNull
+        int radius,
+        String description,
+        boolean isActive
+) {
+    public static Geofence toEntity(GeofenceUpdateRequest request) {
+        return Geofence.builder()
+                .companyCode(request.companyCode)
+                .name(request.name)
+                .latitude(request.latitude)
+                .longitude(request.longitude)
+                .radius(request.radius)
+                .eventType(EventType.OFF)
+                .description(request.description)
+                .isActive(request.isActive)
+                .isActive(false)
+                .build();
+    }
+}

--- a/src/main/java/com/kbe5/rento/domain/geofence/dto/request/GeofenceUpdateRequest.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/dto/request/GeofenceUpdateRequest.java
@@ -2,6 +2,8 @@ package com.kbe5.rento.domain.geofence.dto.request;
 
 import com.kbe5.rento.domain.geofence.entity.Geofence;
 import com.kbe5.rento.domain.geofence.enums.EventType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -20,20 +22,12 @@ public record GeofenceUpdateRequest(
 
         @NotNull
         int radius,
+
+        @NotBlank
+        @Enumerated(EnumType.STRING)
+        EventType eventType,
         String description,
         boolean isActive
 ) {
-    public static Geofence toEntity(GeofenceUpdateRequest request) {
-        return Geofence.builder()
-                .companyCode(request.companyCode)
-                .name(request.name)
-                .latitude(request.latitude)
-                .longitude(request.longitude)
-                .radius(request.radius)
-                .eventType(EventType.OFF)
-                .description(request.description)
-                .isActive(request.isActive)
-                .isActive(false)
-                .build();
-    }
+
 }

--- a/src/main/java/com/kbe5/rento/domain/geofence/dto/response/GeofenceInfoResponse.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/dto/response/GeofenceInfoResponse.java
@@ -1,0 +1,25 @@
+package com.kbe5.rento.domain.geofence.dto.response;
+
+import com.kbe5.rento.domain.geofence.entity.Geofence;
+import com.kbe5.rento.domain.geofence.enums.EventType;
+
+import java.util.List;
+
+public record GeofenceInfoResponse(
+        String name,
+        long latitude,
+        long longitude,
+        int radius,
+        String description,
+        EventType eventType,
+        boolean isActive
+) {
+    public static GeofenceInfoResponse fromEntity(Geofence geofence) {
+        return new GeofenceInfoResponse(geofence.getName(), geofence.getLatitude(), geofence.getLongitude(),
+                geofence.getRadius(), geofence.getDescription(), geofence.getEventType(), geofence.isActive());
+    }
+
+    public static List<GeofenceInfoResponse> fromEntity(List<Geofence> geofenceList) {
+        return geofenceList.stream().map(GeofenceInfoResponse::fromEntity).toList();
+    }
+}

--- a/src/main/java/com/kbe5/rento/domain/geofence/entity/Geofence.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/entity/Geofence.java
@@ -1,0 +1,54 @@
+package com.kbe5.rento.domain.geofence.entity;
+
+import com.kbe5.rento.common.util.BaseEntity;
+import com.kbe5.rento.domain.geofence.enums.EventType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "geofences")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Geofence extends BaseEntity {
+
+    private String companyCode;
+
+    @Column(length = 30)
+    private String name;
+
+    private long latitude;
+    private long longitude;
+    private int radius;
+
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;
+    private String description;
+    private boolean isActive;
+
+    @Builder
+    private Geofence(String companyCode, String name, long latitude, long longitude, int radius, EventType eventType,
+               String description, boolean isActive) {
+        this.companyCode = companyCode;
+        this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.radius = radius;
+        this.eventType = eventType;
+        this.description = description;
+        this.isActive = isActive;
+    }
+
+    public void toUpdate(Geofence newGeofence) {
+        this.name = newGeofence.getName();
+        this.companyCode = newGeofence.getCompanyCode();
+        this.latitude = newGeofence.getLatitude();
+        this.longitude = newGeofence.getLongitude();
+        this.radius = newGeofence.getRadius();
+        this.eventType = newGeofence.getEventType();
+        this.description = newGeofence.getDescription();
+        this.isActive = newGeofence.isActive();
+    }
+}

--- a/src/main/java/com/kbe5/rento/domain/geofence/entity/Geofence.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/entity/Geofence.java
@@ -1,6 +1,7 @@
 package com.kbe5.rento.domain.geofence.entity;
 
 import com.kbe5.rento.common.util.BaseEntity;
+import com.kbe5.rento.domain.geofence.dto.request.GeofenceUpdateRequest;
 import com.kbe5.rento.domain.geofence.enums.EventType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -41,14 +42,14 @@ public class Geofence extends BaseEntity {
         this.isActive = isActive;
     }
 
-    public void toUpdate(Geofence newGeofence) {
-        this.name = newGeofence.getName();
-        this.companyCode = newGeofence.getCompanyCode();
-        this.latitude = newGeofence.getLatitude();
-        this.longitude = newGeofence.getLongitude();
-        this.radius = newGeofence.getRadius();
-        this.eventType = newGeofence.getEventType();
-        this.description = newGeofence.getDescription();
-        this.isActive = newGeofence.isActive();
+    public void toUpdate(GeofenceUpdateRequest request) {
+        this.name = request.name();
+        this.companyCode = request.companyCode();
+        this.latitude = request.latitude();
+        this.longitude = request.longitude();
+        this.radius = request.radius();
+        this.eventType = request.eventType();
+        this.description = request.description();
+        this.isActive = request.isActive();
     }
 }

--- a/src/main/java/com/kbe5/rento/domain/geofence/enums/EventType.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/enums/EventType.java
@@ -1,0 +1,7 @@
+package com.kbe5.rento.domain.geofence.enums;
+
+public enum EventType {
+
+    ON,
+    OFF
+}

--- a/src/main/java/com/kbe5/rento/domain/geofence/repository/GeofenceRepository.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/repository/GeofenceRepository.java
@@ -1,0 +1,11 @@
+package com.kbe5.rento.domain.geofence.repository;
+
+import com.kbe5.rento.domain.geofence.entity.Geofence;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GeofenceRepository extends JpaRepository<Geofence, Long> {
+
+    List<Geofence> findAllByCompanyCode(String companyCode);
+}

--- a/src/main/java/com/kbe5/rento/domain/geofence/service/GeofenceService.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/service/GeofenceService.java
@@ -6,10 +6,13 @@ import com.kbe5.rento.domain.geofence.entity.Geofence;
 import com.kbe5.rento.domain.geofence.repository.GeofenceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class GeofenceService {
 
     private final GeofenceRepository geofenceRepository;
@@ -18,6 +21,7 @@ public class GeofenceService {
         geofenceRepository.save(geofence);
     }
 
+    @Transactional(readOnly = true)
     public List<Geofence> getGeofenceList(String companyCode) {
         List<Geofence> geofenceList = geofenceRepository.findAllByCompanyCode(companyCode);
 
@@ -28,6 +32,7 @@ public class GeofenceService {
         return geofenceList;
     }
 
+    @Transactional(readOnly = true)
     public Geofence getGeofenceDetail(Long id) {
 
         return geofenceRepository.findById(id)

--- a/src/main/java/com/kbe5/rento/domain/geofence/service/GeofenceService.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/service/GeofenceService.java
@@ -1,0 +1,51 @@
+package com.kbe5.rento.domain.geofence.service;
+
+import com.kbe5.rento.common.exception.DomainException;
+import com.kbe5.rento.common.exception.ErrorType;
+import com.kbe5.rento.domain.geofence.entity.Geofence;
+import com.kbe5.rento.domain.geofence.repository.GeofenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GeofenceService {
+
+    private final GeofenceRepository geofenceRepository;
+
+    public void register(Geofence geofence) {
+        geofenceRepository.save(geofence);
+    }
+
+    public List<Geofence> getGeofenceList(String companyCode) {
+        List<Geofence> geofenceList = geofenceRepository.findAllByCompanyCode(companyCode);
+
+        if (geofenceList.isEmpty()) {
+            throw new DomainException(ErrorType.GEOFENCE_NOT_FOUND);
+        }
+
+        return geofenceList;
+    }
+
+    public Geofence getGeofenceDetail(Long id) {
+
+        return geofenceRepository.findById(id)
+                .orElseThrow(() -> new DomainException(ErrorType.COMPANY_NOT_FOUND));
+    }
+
+    public void delete(Long id) {
+        Geofence geofence = geofenceRepository.findById(id)
+                        .orElseThrow(() -> new DomainException(ErrorType.GEOFENCE_NOT_FOUND));
+
+        geofenceRepository.delete(geofence);
+    }
+
+    public void update(Long id, Geofence updatedGeofence) {
+        Geofence geofence = geofenceRepository.findById(id)
+                .orElseThrow(() -> new DomainException(ErrorType.GEOFENCE_NOT_FOUND));
+
+        geofence.toUpdate(updatedGeofence);
+    }
+}
+

--- a/src/main/java/com/kbe5/rento/domain/geofence/service/GeofenceService.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/service/GeofenceService.java
@@ -2,6 +2,7 @@ package com.kbe5.rento.domain.geofence.service;
 
 import com.kbe5.rento.common.exception.DomainException;
 import com.kbe5.rento.common.exception.ErrorType;
+import com.kbe5.rento.domain.geofence.dto.request.GeofenceUpdateRequest;
 import com.kbe5.rento.domain.geofence.entity.Geofence;
 import com.kbe5.rento.domain.geofence.repository.GeofenceRepository;
 import lombok.RequiredArgsConstructor;
@@ -46,11 +47,11 @@ public class GeofenceService {
         geofenceRepository.delete(geofence);
     }
 
-    public void update(Long id, Geofence updatedGeofence) {
+    public void update(Long id, GeofenceUpdateRequest request) {
         Geofence geofence = geofenceRepository.findById(id)
                 .orElseThrow(() -> new DomainException(ErrorType.GEOFENCE_NOT_FOUND));
 
-        geofence.toUpdate(updatedGeofence);
+        geofence.toUpdate(request);
     }
 }
 

--- a/src/main/java/com/kbe5/rento/domain/geofence/service/GeofenceService.java
+++ b/src/main/java/com/kbe5/rento/domain/geofence/service/GeofenceService.java
@@ -11,8 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
 @Transactional
+@RequiredArgsConstructor
 public class GeofenceService {
 
     private final GeofenceRepository geofenceRepository;

--- a/src/test/java/com/kbe5/rento/domain/geofence/service/GeofenceServiceTest.java
+++ b/src/test/java/com/kbe5/rento/domain/geofence/service/GeofenceServiceTest.java
@@ -126,15 +126,14 @@ class GeofenceServiceTest {
     void update() {
         // given
         GeofenceUpdateRequest geofenceUpdateRequest = new GeofenceUpdateRequest("C3",
-                "updatedGeofence", 3214214, 51515214, 21,
+                "updatedGeofence", 3214214, 51515214, 21, EventType.ON,
                 "updatedGeofence", true);
 
-        Geofence updatedGeofence = GeofenceUpdateRequest.toEntity(geofenceUpdateRequest);
 
         given(geofenceRepository.findById(any())).willReturn(Optional.of(geofence));
 
         // when
-        geofenceService.update(geofence.getId(), updatedGeofence);
+        geofenceService.update(geofence.getId(), geofenceUpdateRequest);
 
         // then
         assertThat(geofence.getLatitude()).isEqualTo(geofenceUpdateRequest.latitude());

--- a/src/test/java/com/kbe5/rento/domain/geofence/service/GeofenceServiceTest.java
+++ b/src/test/java/com/kbe5/rento/domain/geofence/service/GeofenceServiceTest.java
@@ -1,0 +1,142 @@
+package com.kbe5.rento.domain.geofence.service;
+
+import com.kbe5.rento.domain.geofence.dto.request.GeofenceUpdateRequest;
+import com.kbe5.rento.domain.geofence.entity.Geofence;
+import com.kbe5.rento.domain.geofence.enums.EventType;
+import com.kbe5.rento.domain.geofence.repository.GeofenceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GeofenceServiceTest {
+
+    @InjectMocks
+    GeofenceService geofenceService;
+
+    @Mock
+    GeofenceRepository geofenceRepository;
+
+    Geofence geofence;
+
+    @BeforeEach
+    void init() {
+        geofence = Geofence.builder()
+                .companyCode("C1")
+                .name("testGeofence")
+                .description("testGeofence")
+                .radius(10)
+                .eventType(EventType.ON)
+                .latitude(1231421)
+                .longitude(3213241)
+                .isActive(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("geofence 등록 테스트")
+    void register() {
+        // given
+        given(geofenceRepository.save(any())).willReturn(geofence);
+
+        // when
+        geofenceService.register(geofence);
+
+        // then
+        verify(geofenceRepository, times(1)).save(geofence); // 호출되었는지 확인
+    }
+
+    @Test
+    @DisplayName("geofence 목록을 불러오는 테스트")
+    void getGeofenceList() {
+        // given
+        Geofence geofence1 = Geofence.builder()
+                .companyCode("C2")
+                .name("testGeofence")
+                .description("testGeofence")
+                .radius(12)
+                .eventType(EventType.ON)
+                .latitude(31313)
+                .longitude(3213241)
+                .isActive(true)
+                .build();
+
+        Geofence geofence2 = Geofence.builder()
+                .companyCode("C2")
+                .name("testGeofence")
+                .description("testGeofence")
+                .radius(13)
+                .eventType(EventType.OFF)
+                .latitude(13323)
+                .longitude(3232)
+                .isActive(true)
+                .build();
+
+        List<Geofence> geofenceList = List.of(geofence1, geofence2);
+
+        given(geofenceRepository.findAllByCompanyCode(any())).willReturn(geofenceList);
+
+        // when
+        List<Geofence> getGeofenceList = geofenceService.getGeofenceList("C2");
+
+        // then
+        assertThat(getGeofenceList).hasSize(2);
+        assertThat(getGeofenceList.get(0).getCompanyCode()).isEqualTo("C2");
+    }
+
+    @Test
+    void getGeofenceDetail() {
+        // given
+        given(geofenceRepository.findById(any())).willReturn(Optional.of(geofence));
+
+        // when
+        Geofence findGeofence = geofenceService.getGeofenceDetail(geofence.getId());
+
+        // then
+        assertThat(findGeofence.getId()).isEqualTo(geofence.getId());
+        assertThat(findGeofence.getName()).isEqualTo(geofence.getName());
+    }
+
+    @Test
+    void delete() {
+        // given
+        given(geofenceRepository.findById(any())).willReturn(Optional.of(geofence));
+
+        // when
+        geofenceService.delete(geofence.getId());
+
+        // then
+        verify(geofenceRepository, times(1)).delete(geofence);
+    }
+
+    @Test
+    void update() {
+        // given
+        GeofenceUpdateRequest geofenceUpdateRequest = new GeofenceUpdateRequest("C3",
+                "updatedGeofence", 3214214, 51515214, 21,
+                "updatedGeofence", true);
+
+        Geofence updatedGeofence = GeofenceUpdateRequest.toEntity(geofenceUpdateRequest);
+
+        given(geofenceRepository.findById(any())).willReturn(Optional.of(geofence));
+
+        // when
+        geofenceService.update(geofence.getId(), updatedGeofence);
+
+        // then
+        assertThat(geofence.getLatitude()).isEqualTo(geofenceUpdateRequest.latitude());
+    }
+}


### PR DESCRIPTION
Geofence CRUD 구현

- resolves #42 

---

### 🚀 어떤 기능을 구현했나요 ?
- Geofence등록, 삭제, 업데이트, 조회 를 하는 CRUD 로직을 구현했습니다.

### 🔥 어떤 문제를 마주했나요 ?
- 등록과 삭제는 Response를 꼭 해줘야 하는지에 대한 고민이 있었습니다.

### ✨ 어떻게 해결했나요 ?
- 등록이나 삭제 시 에러가 발생했을 때 자동으로 내려주기 때문에 굳이 리턴 DTO를 만들지 않고 구현을 했습니다.
