### PR TITLE
Jwt 리펙토링

### DIFF
--- a/src/main/java/com/kbe5/rento/common/exception/ErrorType.java
+++ b/src/main/java/com/kbe5/rento/common/exception/ErrorType.java
@@ -32,6 +32,7 @@ public enum ErrorType {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 없거나 잘못된 형식입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     FAILED_LOGIN(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),
 
     // VEHICLE
     SAME_VEHICLE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 차량 번호입니다."),

--- a/src/main/java/com/kbe5/rento/common/jwt/dto/JwtManagerArgumentDto.java
+++ b/src/main/java/com/kbe5/rento/common/jwt/dto/JwtManagerArgumentDto.java
@@ -2,26 +2,25 @@ package com.kbe5.rento.common.jwt.dto;
 
 import com.kbe5.rento.common.jwt.util.JwtUtil;
 import com.kbe5.rento.domain.manager.entity.Manager;
+import com.kbe5.rento.domain.manager.enums.ManagerRole;
 
 public record JwtManagerArgumentDto(
         Long id,
         String loginId,
         Long companyId,
         String name,
-        String phone,
         String email,
         String companyCode,
         String role
 ) {
     public static JwtManagerArgumentDto fromEntity(Manager manager) {
         return new JwtManagerArgumentDto(manager.getId(), manager.getLoginId(), manager.getCompany().getId(),
-                manager.getName(), manager.getPhone(), manager.getEmail(), manager.getCompanyCode(),
-                manager.getRole().toString());
+                manager.getName(), manager.getEmail(), manager.getCompanyCode(),
+                manager.getRole().getValue());
     }
 
     public static JwtManagerArgumentDto of(JwtUtil util, String token) {
-        return new JwtManagerArgumentDto(util.getId(token), util.getLoginId(token),
-                util.getCompanyId(token), util.getName(token), util.getPhone(token),
-                util.getEmail(token), util.getCompanyCode(token), util.getRole(token));
+        return new JwtManagerArgumentDto(util.getId(token), util.getLoginId(token), util.getCompanyId(token),
+                util.getName(token), util.getEmail(token), util.getCompanyCode(token), util.getRole(token));
     }
 }

--- a/src/main/java/com/kbe5/rento/common/jwt/dto/JwtManagerArgumentDto.java
+++ b/src/main/java/com/kbe5/rento/common/jwt/dto/JwtManagerArgumentDto.java
@@ -1,0 +1,27 @@
+package com.kbe5.rento.common.jwt.dto;
+
+import com.kbe5.rento.common.jwt.util.JwtUtil;
+import com.kbe5.rento.domain.manager.entity.Manager;
+
+public record JwtManagerArgumentDto(
+        Long id,
+        String loginId,
+        Long companyId,
+        String name,
+        String phone,
+        String email,
+        String companyCode,
+        String role
+) {
+    public static JwtManagerArgumentDto fromEntity(Manager manager) {
+        return new JwtManagerArgumentDto(manager.getId(), manager.getLoginId(), manager.getCompany().getId(),
+                manager.getName(), manager.getPhone(), manager.getEmail(), manager.getCompanyCode(),
+                manager.getRole().toString());
+    }
+
+    public static JwtManagerArgumentDto of(JwtUtil util, String token) {
+        return new JwtManagerArgumentDto(util.getId(token), util.getLoginId(token),
+                util.getCompanyId(token), util.getName(token), util.getPhone(token),
+                util.getEmail(token), util.getCompanyCode(token), util.getRole(token));
+    }
+}

--- a/src/main/java/com/kbe5/rento/common/jwt/respository/JwtRefreshRepository.java
+++ b/src/main/java/com/kbe5/rento/common/jwt/respository/JwtRefreshRepository.java
@@ -3,7 +3,10 @@ package com.kbe5.rento.common.jwt.respository;
 import com.kbe5.rento.common.jwt.entity.JwtRefresh;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface JwtRefreshRepository extends JpaRepository<JwtRefresh, Long> {
 
+    Optional<JwtRefresh> findByRefreshToken(String token);
     Boolean existsByRefreshToken(String token);
 }

--- a/src/main/java/com/kbe5/rento/common/jwt/util/JwtFilter.java
+++ b/src/main/java/com/kbe5/rento/common/jwt/util/JwtFilter.java
@@ -1,16 +1,14 @@
 package com.kbe5.rento.common.jwt.util;
 
-import com.kbe5.rento.common.exception.DomainException;
 import com.kbe5.rento.common.exception.ErrorType;
 import com.kbe5.rento.domain.manager.dto.details.CustomManagerDetails;
-import com.kbe5.rento.domain.manager.entity.Manager;
 import com.kbe5.rento.domain.manager.respository.ManagerRepository;
+import com.kbe5.rento.domain.manager.service.CustomMangerDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -51,12 +49,9 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        String loginId = jwtUtil.getLoginId(accessToken);
-
-        Manager manager = managerRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new DomainException(ErrorType.MANAGER_NOT_FOUND));
-
-        CustomManagerDetails customManagerDetails = new CustomManagerDetails(manager);
+        CustomManagerDetails customManagerDetails =
+                (CustomManagerDetails) new CustomMangerDetailsService(managerRepository)
+                        .loadUserByUsername(jwtUtil.getLoginId(accessToken));
 
         Authentication authToken = new UsernamePasswordAuthenticationToken(
                 customManagerDetails, null, customManagerDetails.getAuthorities());

--- a/src/main/java/com/kbe5/rento/common/jwt/util/JwtFilter.java
+++ b/src/main/java/com/kbe5/rento/common/jwt/util/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.kbe5.rento.common.jwt.util;
 
+import com.kbe5.rento.common.exception.DomainException;
 import com.kbe5.rento.common.exception.ErrorType;
 import com.kbe5.rento.domain.manager.dto.details.CustomManagerDetails;
 import com.kbe5.rento.domain.manager.respository.ManagerRepository;
@@ -30,33 +31,37 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request,@NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String accessToken = request.getHeader("AccessToken");
 
-        String accessToken = request.getHeader("AccessToken");
+            if (accessToken == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
 
-        if (accessToken == null) {
-            filterChain.doFilter(request, response);
-            return;
+            if (jwtUtil.isExpired(accessToken)) {
+                return;
+            }
+
+            String category = jwtUtil.getCategory(accessToken);
+
+            if (!category.equals("access")) {
+                DomainException domainException = new DomainException(ErrorType.INVALID_TOKEN);
+                jwtUtil.tokenErrorResponse(response, domainException);
+                return;
+            }
+
+            CustomManagerDetails customManagerDetails =
+                    (CustomManagerDetails) new CustomMangerDetailsService(managerRepository)
+                            .loadUserByUsername(jwtUtil.getLoginId(accessToken));
+
+            Authentication authToken = new UsernamePasswordAuthenticationToken(
+                    customManagerDetails, null, customManagerDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        } catch (DomainException e) {
+            jwtUtil.tokenErrorResponse(response, e);
         }
-
-        if (jwtUtil.isExpired(accessToken)) {
-            return;
-        }
-
-        String category = jwtUtil.getCategory(accessToken);
-
-        if (!category.equals("access")) {
-            jwtUtil.tokenErrorResponse(response, ErrorType.INVALID_TOKEN);
-            return;
-        }
-
-        CustomManagerDetails customManagerDetails =
-                (CustomManagerDetails) new CustomMangerDetailsService(managerRepository)
-                        .loadUserByUsername(jwtUtil.getLoginId(accessToken));
-
-        Authentication authToken = new UsernamePasswordAuthenticationToken(
-                customManagerDetails, null, customManagerDetails.getAuthorities());
-
-        SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/kbe5/rento/common/jwt/util/JwtUtil.java
+++ b/src/main/java/com/kbe5/rento/common/jwt/util/JwtUtil.java
@@ -31,101 +31,36 @@ public class JwtUtil {
                 Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public String getLoginId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-                .get("loginId", String.class);
-    }
-
     public String getRole(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-                .get("role", String.class);
+        return parseClaim(token, "role", String.class);
     }
 
     public String getCategory(String token) {
-        try {
-            return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-                    .get("category", String.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new DomainException(ErrorType.INVALID_TOKEN);
-        }
+        return parseClaim(token, "category", String.class);
     }
 
     public Long getId(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("id", Long.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new DomainException(ErrorType.INVALID_TOKEN);
-        }
-    }
-
-    public Long getCompanyId(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("company", Long.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new DomainException(ErrorType.INVALID_TOKEN);
-        }
-    }
-
-    public String getCompanyCode(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("companyCode", String.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new DomainException(ErrorType.INVALID_TOKEN);
-        }
-    }
-
-    public String getEmail(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("email", String.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new DomainException(ErrorType.INVALID_TOKEN);
-        }
+        return parseClaim(token, "id", Long.class);
     }
 
     public String getName(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("name", String.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new DomainException(ErrorType.INVALID_TOKEN);
-        }
+        return parseClaim(token, "name", String.class);
     }
 
-    public String getPhone(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("phone", String.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new DomainException(ErrorType.INVALID_TOKEN);
-        }
+    public String getLoginId(String token) {
+        return parseClaim(token, "loginId", String.class);
+    }
+
+    public String getEmail(String token) {
+        return parseClaim(token, "email", String.class);
+    }
+
+    public Long getCompanyId(String token) {
+        return parseClaim(token, "companyId", Long.class);
+    }
+
+    public String getCompanyCode(String token) {
+        return parseClaim(token, "companyCode", String.class);
     }
 
     public Boolean isExpired(String token) {
@@ -140,7 +75,20 @@ public class JwtUtil {
             return expiration.before(new Date());
 
         } catch (JwtException | IllegalArgumentException e) {
-            throw new DomainException(ErrorType.EXPIRED_TOKEN);
+           throw new DomainException(ErrorType.EXPIRED_TOKEN);
+        }
+    }
+
+    private <T> T parseClaim(String token, String claimKey, Class<T> clazz) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get(claimKey, clazz);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new DomainException(ErrorType.INVALID_TOKEN);
         }
     }
 
@@ -154,25 +102,10 @@ public class JwtUtil {
                 .claim("companyCode", dto.companyCode())
                 .claim("email", dto.email())
                 .claim("name", dto.name())
-                .claim("phone", dto.phone())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)
                 .compact();
-    }
-
-    public void saveRefreshToken(String refreshToken, Manager manager, Long expiredTime) {
-        if (jwtRefreshRepository.existsByRefreshToken(refreshToken)) {
-            JwtRefresh jwtRefresh = jwtRefreshRepository.findByRefreshToken(refreshToken)
-                            .orElseThrow(() -> new DomainException(ErrorType.REFRESH_TOKEN_NOT_FOUND));
-            jwtRefreshRepository.delete(jwtRefresh);
-        };
-
-        jwtRefreshRepository.save(JwtRefresh.builder()
-                        .manager(manager)
-                        .refreshToken(refreshToken)
-                        .expiredTime(expiredTime)
-                        .build());
     }
 
     public void getNewAccessToken(HttpServletRequest request, HttpServletResponse response) {
@@ -194,7 +127,7 @@ public class JwtUtil {
         JwtManagerArgumentDto managerArgumentDto = JwtManagerArgumentDto.of(this, refresh);
 
         String newAccess = createJwt("access", managerArgumentDto, JwtProperties.ACCESS_EXPIRED_TIME);
-        String newRefresh = createJwt("refresh", managerArgumentDto, JwtProperties.ACCESS_EXPIRED_TIME);
+        String newRefresh = createJwt("refresh", managerArgumentDto, JwtProperties.REFRESH_EXPIRED_TIME);
 
         JwtRefresh oldRefreshToken = jwtRefreshRepository.findByRefreshToken(refresh)
                 .orElseThrow(() -> new DomainException(ErrorType.REFRESH_TOKEN_NOT_FOUND));
@@ -207,8 +140,25 @@ public class JwtUtil {
         response.setHeader("RefreshToken", newRefresh);
     }
 
-    public void tokenErrorResponse(HttpServletResponse response, ErrorType errorType) throws IOException {
-        DomainException domainException = new DomainException(errorType);
+    public void saveRefreshToken(String refreshToken, Manager manager, Long expiredTime) {
+        if (jwtRefreshRepository.existsByRefreshToken(refreshToken)) {
+            JwtRefresh jwtRefresh = jwtRefreshRepository.findByRefreshToken(refreshToken)
+                    .orElseThrow(() -> new DomainException(ErrorType.REFRESH_TOKEN_NOT_FOUND));
+            deleteRefreshToken(jwtRefresh);
+        };
+
+        jwtRefreshRepository.save(JwtRefresh.builder()
+                .manager(manager)
+                .refreshToken(refreshToken)
+                .expiredTime(expiredTime)
+                .build());
+    }
+
+    public void deleteRefreshToken(JwtRefresh oldRefreshToken) {
+        jwtRefreshRepository.delete(oldRefreshToken);
+    }
+
+    public void tokenErrorResponse(HttpServletResponse response, DomainException domainException) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
 
         response.setStatus(domainException.getStatus().value());
@@ -216,9 +166,5 @@ public class JwtUtil {
         String body = new ObjectMapper().writeValueAsString(domainException.toResponse());
 
         response.getWriter().write(body);
-    }
-
-    public void deleteRefreshToken(JwtRefresh oldRefreshToken) {
-        jwtRefreshRepository.delete(oldRefreshToken);
     }
 }

--- a/src/main/java/com/kbe5/rento/common/securityFilter/LoginAuthenticationFilter.java
+++ b/src/main/java/com/kbe5/rento/common/securityFilter/LoginAuthenticationFilter.java
@@ -77,7 +77,7 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
 
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
-
-        jwtUtil.tokenErrorResponse(response, ErrorType.FAILED_LOGIN);
+        DomainException domainException = new DomainException(ErrorType.FAILED_LOGIN);
+        jwtUtil.tokenErrorResponse(response, domainException);
     }
 }

--- a/src/main/java/com/kbe5/rento/common/util/SecurityPermissionApiList.java
+++ b/src/main/java/com/kbe5/rento/common/util/SecurityPermissionApiList.java
@@ -65,6 +65,9 @@ public class SecurityPermissionApiList {
 
             // login && signUp
             "/api/managers/login",
-            "/api/managers/sign-up"
+            "/api/managers/sign-up",
+
+            // refresh
+            "/api/managers/refresh"
     };
 }

--- a/src/main/java/com/kbe5/rento/domain/manager/entity/Manager.java
+++ b/src/main/java/com/kbe5/rento/domain/manager/entity/Manager.java
@@ -1,19 +1,15 @@
 package com.kbe5.rento.domain.manager.entity;
 
-import com.kbe5.rento.domain.company.entity.Company;
 import com.kbe5.rento.common.util.BaseEntity;
-import com.kbe5.rento.domain.company.repository.CompanyRepository;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
+import com.kbe5.rento.domain.company.entity.Company;
 import com.kbe5.rento.domain.manager.dto.request.ManagerUpdateRequest;
 import com.kbe5.rento.domain.manager.enums.ManagerRole;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;import org.springframework.security.crypto.password.PasswordEncoder;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Getter
@@ -42,7 +38,7 @@ public class Manager extends BaseEntity {
     @Column(length = 30)
     private String companyCode;
 
-    @Column(length = 10)
+    @Column(length = 20)
     @Enumerated(EnumType.STRING)
     private ManagerRole role;
 

--- a/src/test/java/com/kbe5/rento/common/util/JwtUtilTest.java
+++ b/src/test/java/com/kbe5/rento/common/util/JwtUtilTest.java
@@ -81,7 +81,7 @@ class JwtUtilTest {
         manager = managerRepository.save(manager);
 
         jwtManagerArgumentDto = new JwtManagerArgumentDto(1L, manager.getLoginId(), 1L, manager.getName(),
-                manager.getPhone(), manager.getEmail(), manager.getCompanyCode(), manager.getRole().toString());
+                manager.getEmail(), manager.getCompanyCode(), manager.getRole().toString());
 
         accessToken = jwtUtil.createJwt("access", jwtManagerArgumentDto, 60000L);
         refreshToken = jwtUtil.createJwt("refresh", jwtManagerArgumentDto, 60000L);


### PR DESCRIPTION
Jwt 리펙토링

- resolves #59 

---

### 🚀 어떤 기능을 구현했나요 ?
- 로그인 성공 후 jwt 토큰을 발급하고 api요청 시 필터를 거칠 때 DB를 한번 더 거치는 과정을 수정하려고 했으나, 바로 ManagerRepository에서 불러오지 않을 뿐, CustomDetailsService에서 LoadByUsername으로 불러오고 있습니다.
- 리프레시 토큰이 이미 디비에 있는 경우 삭제하고 새로운 토큰으로 바꾸고, 리프레스 토큰을 재발급 했을 때도 삭제 후 새로운 토큰으로 교체하는 로직을 구현했습니다.

### 🔥 어떤 문제를 마주했나요 ?
- 로그인 한번만 할 때 DB에 접근하고 싶었지만, 현재는 요청 시 마다 디비에 한번 씩 접근하고 있습니다.

### ✨ 어떻게 해결했나요 ?
-  아직 해결하지 못 한 상태이며, 해결을 하려면 생각보다 사이드 이펙트가 많이 생겨서 급하지 않으니 추 후에 바로 해결 할 생각입니다.