### PR TITLE
[BE] 매니저 로그아웃 시 refresh token 삭제하기

### DIFF
--- a/src/main/java/com/kbe5/rento/common/jwt/respository/JwtRefreshRepository.java
+++ b/src/main/java/com/kbe5/rento/common/jwt/respository/JwtRefreshRepository.java
@@ -9,4 +9,6 @@ public interface JwtRefreshRepository extends JpaRepository<JwtRefresh, Long> {
 
     Optional<JwtRefresh> findByRefreshToken(String token);
     Boolean existsByRefreshToken(String token);
+
+    Optional<JwtRefresh> findByManagerId(Long managerId);
 }

--- a/src/main/java/com/kbe5/rento/common/util/SecurityPermissionApiList.java
+++ b/src/main/java/com/kbe5/rento/common/util/SecurityPermissionApiList.java
@@ -66,6 +66,9 @@ public class SecurityPermissionApiList {
             // login && signUp
             "/api/managers/login",
             "/api/managers/sign-up",
+            "/api/managers/check-loginId/{loginId}",
+            "/api/managers/{email}",
+            "/api/managers/logout",
 
             // refresh
             "/api/managers/refresh",

--- a/src/main/java/com/kbe5/rento/domain/event/dto/request/cycleinfo/CycleInfoRequest.java
+++ b/src/main/java/com/kbe5/rento/domain/event/dto/request/cycleinfo/CycleInfoRequest.java
@@ -58,6 +58,7 @@ public record CycleInfoRequest(
 
     @Min(0)
     @Max(9999)
+    @JsonProperty("bat")
     @NotBlank(message = "bat(배터리 전압)은 필수입니다.")
     Integer battery
 ){

--- a/src/main/java/com/kbe5/rento/domain/manager/controller/ManagerControllerImpl.java
+++ b/src/main/java/com/kbe5/rento/domain/manager/controller/ManagerControllerImpl.java
@@ -3,13 +3,16 @@ package com.kbe5.rento.domain.manager.controller;
 import com.kbe5.rento.common.apiresponse.ApiResponse;
 import com.kbe5.rento.common.apiresponse.ApiResultCode;
 import com.kbe5.rento.common.apiresponse.ResEntityFactory;
+import com.kbe5.rento.domain.manager.dto.details.CustomManagerDetails;
 import com.kbe5.rento.domain.manager.dto.request.*;
 import com.kbe5.rento.domain.manager.dto.response.*;
 import com.kbe5.rento.domain.manager.entity.Manager;
 import com.kbe5.rento.domain.manager.service.ManagerService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -61,8 +64,19 @@ public class ManagerControllerImpl implements ManagerController {
     }
 
     @GetMapping("/{email}")
-    public ResponseEntity<ApiResponse<Boolean>> checkAvailableEmail(@PathVariable String email) {
+    public ResponseEntity<ApiResponse<Boolean>> checkAvailableEmail( String email) {
         return ResEntityFactory.toResponse(ApiResultCode.SUCCESS,
                 !managerService.isExistsEmail(email));
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout(
+            @AuthenticationPrincipal CustomManagerDetails customManagerDetails) {
+        Manager manager = customManagerDetails.getManager();
+
+        managerService.logout(manager.getId());
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, "로그아웃이 성공적으로 처리되었습니다");
+    }
+
 }

--- a/src/main/java/com/kbe5/rento/domain/manager/controller/ManagerControllerImpl.java
+++ b/src/main/java/com/kbe5/rento/domain/manager/controller/ManagerControllerImpl.java
@@ -64,7 +64,7 @@ public class ManagerControllerImpl implements ManagerController {
     }
 
     @GetMapping("/{email}")
-    public ResponseEntity<ApiResponse<Boolean>> checkAvailableEmail( String email) {
+    public ResponseEntity<ApiResponse<Boolean>> checkAvailableEmail(@PathVariable String email) {
         return ResEntityFactory.toResponse(ApiResultCode.SUCCESS,
                 !managerService.isExistsEmail(email));
     }

--- a/src/main/java/com/kbe5/rento/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/kbe5/rento/domain/manager/service/ManagerService.java
@@ -2,6 +2,8 @@ package com.kbe5.rento.domain.manager.service;
 
 import com.kbe5.rento.common.exception.DomainException;
 import com.kbe5.rento.common.exception.ErrorType;
+import com.kbe5.rento.common.jwt.entity.JwtRefresh;
+import com.kbe5.rento.common.jwt.respository.JwtRefreshRepository;
 import com.kbe5.rento.domain.company.dto.response.CompanyResponse;
 import com.kbe5.rento.domain.company.entity.Company;
 import com.kbe5.rento.domain.company.repository.CompanyRepository;
@@ -32,6 +34,7 @@ public class ManagerService {
     private final ManagerRepository managerRepository;
     private final CompanyRepository companyRepository;
     private final PasswordEncoder encoder;
+    private final JwtRefreshRepository jwtRefreshRepository;
 
     public Manager signUp(Manager manager) {
         Company company = companyRepository.findByCompanyCode(manager.getCompanyCode())
@@ -64,6 +67,14 @@ public class ManagerService {
         }
 
         return ManagerList;
+    }
+
+    @Transactional
+    public void logout(Long managerId){
+        JwtRefresh jwtRefresh = jwtRefreshRepository.findByManagerId(managerId)
+                .orElseThrow(() -> new DomainException(ErrorType.REFRESH_TOKEN_NOT_FOUND));
+
+        jwtRefreshRepository.delete(jwtRefresh);
     }
 
     public Manager update(Long id, ManagerUpdateRequest request) {


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #74 

---

### 🚀 어떤 기능을 구현했나요 ?
- 로그아웃 시에 refresh token을 삭제하는 것을 구현했습니다

### 🔥 어떤 문제를 마주했나요 ?
- 처음에 
```
public ResponseEntity<ApiResponse<String>> logout(HttpServletRequest request) {
    String refreshToken = request.getHeader("RefreshToken");
```
을 사용하여 refreshToken을 가져왔는데 만들어있던 기능인
`@AuthenticationPrincipal`을 사용하여 다시 구현하였습니다.

### ✨ 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
