### PR TITLE
[BE] 사용자 등록 및 업데이트 시 중복 값 체크 변경

### DIFF
--- a/src/main/java/com/kbe5/rento/common/exception/ErrorType.java
+++ b/src/main/java/com/kbe5/rento/common/exception/ErrorType.java
@@ -27,6 +27,8 @@ public enum ErrorType {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 존재하는 전화번호입니다."),
     INVALID_POSITION(HttpStatus.BAD_REQUEST, "존재하지 않은 직책입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다." ),
+    DUPLICATE_LOGIN_ID(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다." ),
 
     // SECURITY
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 없거나 잘못된 형식입니다."),

--- a/src/main/java/com/kbe5/rento/common/util/SecurityPermissionApiList.java
+++ b/src/main/java/com/kbe5/rento/common/util/SecurityPermissionApiList.java
@@ -57,6 +57,7 @@ public class SecurityPermissionApiList {
 //
 //            // Company APIs
             "/api/companies/register",
+            "/api/companies/check-bizNumber",
 //            "/api/companies",
 //            "/api/companies/{companyId}",
 

--- a/src/main/java/com/kbe5/rento/domain/member/controller/MemberControllerImpl.java
+++ b/src/main/java/com/kbe5/rento/domain/member/controller/MemberControllerImpl.java
@@ -83,4 +83,23 @@ public class MemberControllerImpl implements MemberController {
     public ResponseEntity<ApiResponse<List<String>>> getPositions() {
         return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, Position.getPositions());
     }
+
+    //아이디 중복 체크
+    @GetMapping("/check-id/{loginId}")
+    public ResponseEntity<ApiResponse<Boolean>> checkId(
+            @PathVariable String loginId) {
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistLoginId(loginId));
+    }
+
+    //이메일 중복 체크
+    @GetMapping("/check-email/{email}")
+    public ResponseEntity<ApiResponse<Boolean>> checkEmail(@PathVariable String email) {
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistEmail(email));
+    }
+
+    //전화번호 중복 체크
+    @GetMapping("/check-phone/{phoneNumber}")
+    public ResponseEntity<ApiResponse<Boolean>> checkPhoneNumber(@PathVariable String phoneNumber) {
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistPhoneNumber(phoneNumber));
+    }
 }

--- a/src/main/java/com/kbe5/rento/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kbe5/rento/domain/member/repository/MemberRepository.java
@@ -10,5 +10,15 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findAllByCompanyId(Long id);
 
+    Member findByPhoneNumberAndCompanyId(String phoneNumber, Long id);
+
     boolean existsByPhoneNumberAndCompanyId(String phoneNumber, Long id);
+
+    boolean existsByEmailAndCompanyId(String email, Long id);
+
+    boolean existsByLoginIdAndCompanyId(String loginId, Long id);
+
+    Member findByEmailAndCompanyId(String email, Long id);
+
+    Member findByLoginIdAndCompanyId(String loginId, Long id);
 }

--- a/src/main/java/com/kbe5/rento/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kbe5/rento/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.kbe5.rento.domain.member.repository;
 
 import com.kbe5.rento.domain.member.entity.Member;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,16 +10,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByDepartmentId(Long id);
 
     List<Member> findAllByCompanyId(Long id);
+    
+    boolean existsByLoginId(String loginId);
 
-    Member findByPhoneNumberAndCompanyId(String phoneNumber, Long id);
+    boolean existsByEmail(String email);
 
-    boolean existsByPhoneNumberAndCompanyId(String phoneNumber, Long id);
+    boolean existsByPhoneNumber(String phoneNumber);
 
-    boolean existsByEmailAndCompanyId(String email, Long id);
+    boolean existsByEmailAndIdNot(String email, Long memberId);
 
-    boolean existsByLoginIdAndCompanyId(String loginId, Long id);
+    boolean existsByLoginIdAndIdNot(String loginId, Long memberId);
 
-    Member findByEmailAndCompanyId(String email, Long id);
-
-    Member findByLoginIdAndCompanyId(String loginId, Long id);
+    boolean existsByPhoneNumberAndIdNot(String phoneNumber, Long memberId);
 }

--- a/src/main/java/com/kbe5/rento/domain/member/service/MemberService.java
+++ b/src/main/java/com/kbe5/rento/domain/member/service/MemberService.java
@@ -35,13 +35,12 @@ public class MemberService {
 
         member.encodePassword(passwordEncoder);
 
-        Company company = companyRepository.findByCompanyCode(member.getCompanyCode())
-                .orElseThrow(() -> new DomainException(ErrorType.COMPANY_NOT_FOUND));
-        Department department = departmentRepository.findById(departmentId)
-                .orElseThrow(() -> new DomainException(ErrorType.DEPARTMENT_NOT_FOUND));
-
-        member.assignCompany(company);
-        member.assignDepartment(department);
+        member.assignCompany(companyRepository.findByCompanyCode(member.getCompanyCode()).orElseThrow(
+                () -> new DomainException(ErrorType.COMPANY_NOT_FOUND))
+        );
+        member.assignDepartment(departmentRepository.findById(departmentId).orElseThrow(
+                () -> new DomainException(ErrorType.DEPARTMENT_NOT_FOUND))
+        );
 
         return memberRepository.save(member);
     }

--- a/src/main/java/com/kbe5/rento/domain/member/service/MemberService.java
+++ b/src/main/java/com/kbe5/rento/domain/member/service/MemberService.java
@@ -122,6 +122,7 @@ public class MemberService {
                 .orElseThrow(() -> new DomainException(ErrorType.MEMBER_NOT_FOUND));
     }
 
+    //todo: 기업별로도 확인하기
     public boolean isExistLoginId(String loginId) {
         return memberRepository.existsByLoginId(loginId);
     }

--- a/src/test/java/com/kbe5/rento/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kbe5/rento/domain/member/service/MemberServiceTest.java
@@ -151,7 +151,6 @@ class MemberServiceTest {
 
         // 중복 아님
         when(companyRepository.findByCompanyCode("T1")).thenReturn(Optional.of(company));
-        when(memberRepository.existsByPhoneNumberAndCompanyId("010-9999-8888", 1L)).thenReturn(false);
 
         // when
         MemberInfoResponse result = memberService.update(manager, request, memberId);

--- a/src/test/java/com/kbe5/rento/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kbe5/rento/domain/member/service/MemberServiceTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,11 +64,10 @@ class MemberServiceTest {
     @DisplayName("회원 등록 성공")
     void register_Success() {
         // given
-        when(company.getId()).thenReturn(1L);
+        given(memberRepository.save(any())).willReturn(member);
 
         // register에 실제 전달하는 member에 대한 stub 필요
         when(member.getCompanyCode()).thenReturn("T1");
-        when(member.getPhoneNumber()).thenReturn("010-1234-5678");
 
         when(companyRepository.findByCompanyCode("T1")).thenReturn(Optional.of(company));
         when(departmentRepository.findById(1L)).thenReturn(Optional.of(department));
@@ -78,7 +78,7 @@ class MemberServiceTest {
 
         // then
         assertThat(result.getCompanyCode()).isEqualTo("T1");
-        verify(companyRepository, times(2)).findByCompanyCode("T1");
+        verify(companyRepository, times(1)).findByCompanyCode("T1");
         verify(memberRepository, times(1)).save(any(Member.class));
     }
 
@@ -88,7 +88,6 @@ class MemberServiceTest {
     void register_DepartmentNotFound() {
         //given
         when(member.getCompanyCode()).thenReturn("T1");
-        when(member.getPhoneNumber()).thenReturn("010-1234-5678");
 
         when(companyRepository.findByCompanyCode("T1")).thenReturn(Optional.of(company));
         when(departmentRepository.findById(any())).thenReturn(Optional.empty());
@@ -102,22 +101,9 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("회원 등록 시 전화번호 중복인 경우")
+    @DisplayName("전화번호 중복체크")
     void register_Duplicate_Phone_Number(){
-        //given
-        when(member.getCompanyCode()).thenReturn("T1");
-        when(member.getPhoneNumber()).thenReturn("010-1234-5678");
 
-        when(company.getId()).thenReturn(1L);
-        when(companyRepository.findByCompanyCode("T1")).thenReturn(Optional.of(company));
-        when(memberRepository.existsByPhoneNumberAndCompanyId("010-1234-5678", 1L)).thenReturn(true);
-
-        //when & then
-        assertThatThrownBy(() -> memberService.register(member, 1L))
-        .isInstanceOf(DomainException.class)
-                .hasMessage(ErrorType.DUPLICATE_PHONE_NUMBER.getMessage());
-
-        verify(memberRepository, never()).save(any(Member.class));
     }
 
     @Test
@@ -135,8 +121,6 @@ class MemberServiceTest {
         when(departmentRepository.findById(departmentId)).thenReturn(Optional.of(department));
 
         when(request.departmentId()).thenReturn(departmentId);
-        when(request.phoneNumber()).thenReturn("010-9999-8888");
-        when(request.companyCode()).thenReturn("T1");
 
         // 기타 업데이트 필드도 mock
         when(request.name()).thenReturn("수정된이름");
@@ -148,9 +132,6 @@ class MemberServiceTest {
 
         when(member.getDepartment()).thenReturn(department);
         when(department.getId()).thenReturn(2L);
-
-        // 중복 아님
-        when(companyRepository.findByCompanyCode("T1")).thenReturn(Optional.of(company));
 
         // when
         MemberInfoResponse result = memberService.update(manager, request, memberId);

--- a/src/test/java/com/kbe5/rento/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kbe5/rento/domain/member/service/MemberServiceTest.java
@@ -24,8 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -103,6 +102,14 @@ class MemberServiceTest {
     @Test
     @DisplayName("전화번호 중복체크")
     void register_Duplicate_Phone_Number(){
+        //given
+        when(memberRepository.existsByPhoneNumber("01011111111")).thenReturn(true);
+
+        //when
+        boolean result = memberService.isExistPhoneNumber("01011111111");
+
+        //then
+        assertThat(result).isTrue();
 
     }
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #79 

---

### 🚀 어떤 기능을 구현했나요 ?
- 사용자 등록 및 정보 수정 시 중복 값을 기존 이메일, 전화번호 였던 것을 아이디, 이메일, 전화번호 중복 체크로 변경하였습니다!

### 🔥 어떤 문제를 마주했나요 ?
- 정보 수정할 때, 자신의 정보를 수정하는데도 중복이 체크되어 수정이 안되었습니다

### ✨ 어떻게 해결했나요 ?
- 새로 등록과 정보 수정 메서드를 분리하여 문제를 해결하였습니다

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 전체 DB에서 중복이 안되게하지 않고, 기업별로 구분지어 중복 값을 체크하는데,, 중복 메서드가 많이 나오고 코드의 수가 많이 길어진 거 같아 고민입니다. `Service`쪽 메서드를 주의깊게 봐주세요!

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
