### PR TITLE
[BE] fcm 저장하는 api 구현

### DIFF
--- a/src/main/java/com/kbe5/rento/common/config/FCMInitializer.java
+++ b/src/main/java/com/kbe5/rento/common/config/FCMInitializer.java
@@ -5,11 +5,13 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 @Slf4j
 @Component
@@ -20,7 +22,7 @@ public class FCMInitializer {
 
     @PostConstruct
     public void init() {
-        try (var inputStream = new FileInputStream(firebaseConfigPath)) {
+        try (InputStream inputStream = getFirebaseConfigInputStream()) {
             GoogleCredentials googleCredentials = GoogleCredentials.fromStream(inputStream);
 
             FirebaseOptions options = new FirebaseOptions.Builder()
@@ -33,6 +35,14 @@ public class FCMInitializer {
             }
         } catch (IOException e) {
             log.error("Firebase 초기화 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    private InputStream getFirebaseConfigInputStream() throws IOException {
+        if (firebaseConfigPath.startsWith("/") || firebaseConfigPath.startsWith("./")) {
+            return new FileInputStream(firebaseConfigPath);
+        } else {
+            return new ClassPathResource(firebaseConfigPath).getInputStream();
         }
     }
 }

--- a/src/main/java/com/kbe5/rento/common/securityFilter/LoginAuthenticationFilter.java
+++ b/src/main/java/com/kbe5/rento/common/securityFilter/LoginAuthenticationFilter.java
@@ -40,8 +40,6 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
             ObjectMapper mapper = new ObjectMapper();
             ManagerLoginRequest loginRequest = mapper.readValue(request.getInputStream(), ManagerLoginRequest.class);
 
-            request.setAttribute("loginRequest", loginRequest);
-
             String loginId = loginRequest.loginId();
             String password = loginRequest.password();
 
@@ -57,15 +55,9 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
         CustomManagerDetails customManagerDetails = (CustomManagerDetails) authResult.getPrincipal();
-
         Manager manager = customManagerDetails.getManager();
 
         JwtManagerArgumentDto managerArgumentDto = JwtManagerArgumentDto.fromEntity(manager);
-
-        ManagerLoginRequest loginRequest = (ManagerLoginRequest) request.getAttribute("loginRequest");
-        String fcmToken = loginRequest.fcmToken();
-
-        manager.assignFcmToken(fcmToken);
 
         String accessToken = jwtUtil.createJwt("access", managerArgumentDto, JwtProperties.ACCESS_EXPIRED_TIME);
         String refreshToken = jwtUtil.createJwt("refresh", managerArgumentDto, JwtProperties.REFRESH_EXPIRED_TIME);

--- a/src/main/java/com/kbe5/rento/domain/firebase/dto/UpdateFcmTokenRequest.java
+++ b/src/main/java/com/kbe5/rento/domain/firebase/dto/UpdateFcmTokenRequest.java
@@ -1,0 +1,6 @@
+package com.kbe5.rento.domain.firebase.dto;
+
+public record UpdateFcmTokenRequest(
+        String token
+) {
+}

--- a/src/main/java/com/kbe5/rento/domain/manager/controller/ManagerControllerImpl.java
+++ b/src/main/java/com/kbe5/rento/domain/manager/controller/ManagerControllerImpl.java
@@ -3,12 +3,12 @@ package com.kbe5.rento.domain.manager.controller;
 import com.kbe5.rento.common.apiresponse.ApiResponse;
 import com.kbe5.rento.common.apiresponse.ApiResultCode;
 import com.kbe5.rento.common.apiresponse.ResEntityFactory;
+import com.kbe5.rento.domain.firebase.dto.UpdateFcmTokenRequest;
 import com.kbe5.rento.domain.manager.dto.details.CustomManagerDetails;
 import com.kbe5.rento.domain.manager.dto.request.*;
 import com.kbe5.rento.domain.manager.dto.response.*;
 import com.kbe5.rento.domain.manager.entity.Manager;
 import com.kbe5.rento.domain.manager.service.ManagerService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -79,4 +79,15 @@ public class ManagerControllerImpl implements ManagerController {
         return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, "로그아웃이 성공적으로 처리되었습니다");
     }
 
+    @PatchMapping("/fcm-token")
+    public ResponseEntity<ApiResponse<String>> updateFcmToken(
+            @RequestBody UpdateFcmTokenRequest tokenRequest,
+            @AuthenticationPrincipal CustomManagerDetails customManagerDetails
+            ){
+        Long managerId = customManagerDetails.getManager().getId();
+
+        managerService.updateFcmToken(managerId, tokenRequest);
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, "FCM Token이 성공적으로 저장되었습니다.");
+    }
 }

--- a/src/main/java/com/kbe5/rento/domain/manager/dto/request/ManagerLoginRequest.java
+++ b/src/main/java/com/kbe5/rento/domain/manager/dto/request/ManagerLoginRequest.java
@@ -2,7 +2,6 @@ package com.kbe5.rento.domain.manager.dto.request;
 
 public record ManagerLoginRequest(
         String loginId,
-        String password,
-        String fcmToken
+        String password
 ) {
 }

--- a/src/main/java/com/kbe5/rento/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/kbe5/rento/domain/manager/service/ManagerService.java
@@ -8,6 +8,7 @@ import com.kbe5.rento.domain.company.dto.response.CompanyResponse;
 import com.kbe5.rento.domain.company.entity.Company;
 import com.kbe5.rento.domain.company.repository.CompanyRepository;
 import com.kbe5.rento.domain.company.service.CompanyService;
+import com.kbe5.rento.domain.firebase.dto.UpdateFcmTokenRequest;
 import com.kbe5.rento.domain.manager.dto.request.ManagerDeleteRequest;
 import com.kbe5.rento.domain.manager.dto.request.ManagerSignUpRequest;
 import com.kbe5.rento.domain.manager.dto.request.ManagerUpdateRequest;
@@ -109,5 +110,12 @@ public class ManagerService {
 
     public boolean isExistsEmail(String email) {
         return managerRepository.existsByEmail(email);
+    }
+
+    public void updateFcmToken(Long managerId, UpdateFcmTokenRequest tokenRequest) {
+        Manager manager = managerRepository.findById(managerId)
+                .orElseThrow(() -> new DomainException(ErrorType.MANAGER_NOT_FOUND));
+
+        manager.assignFcmToken(tokenRequest.token());
     }
 }

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -29,3 +29,6 @@ spring:
     port: 5672
     username: guest
     password: guest
+
+fcm:
+  firebase_config_path: ${FIREBASE_PATH}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,3 +35,7 @@ server:
       max: 200
       min-spare: 10
     accept-count: 100
+
+fcm:
+  firebase_config_path: firebase/rento-f1d61-firebase-adminsdk-fbsvc-bd76cc388d.json
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,3 @@ spring:
   messages:
     basename: messages
     encoding: UTF-8
-
-fcm:
-  firebase_config_path: ${FIREBASE_PATH}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #125 

---

### 🚀 어떤 기능을 구현했나요 ?
- fcm 발급해주는 api 구현

### 🔥 어떤 문제를 마주했나요 ?
- `FCMInitializer`에서 firebase 경로를 못 읽는 문제가 발생했습니다

### ✨ 어떻게 해결했나요 ?
- `FileInputStream'은 OS의 절대경로/상대경로를 파일 시스템에서 직접 읽고 `ClassPathResource`는 resources에서 읽어옵니다! 그렇기에 if문으로 개발환경에서는 `ClassPathResource`를 사용하여 `resource/`에 `json`을 넣고 편하게 실행할 수 있게 하고, 배포 환경에서는 `FileInputStream`을 사용하여 `CI/CD`로 외부 `json`을 생성하고 읽어오게 하였습니다!
- "/"로 시작하면 절대경로(배포용)이기에 `FileInputStream`을 사용하고, "./"로 시작하면 현재 디렉토리 기준 상대경로(개발용)이기에 `ClassPathResource`를 사용하게 하였습니다!

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 배포를 해봐야 파일 경로를 잘 읽어올 지 알 수 있을 거같습니다 ㅠ 로컬에서도 확인할 수 있는 방법이 있으면 알려주시면 감사하겠습니다!

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
