### PR TITLE
[BE] @RequestHeader 를 사용해서 deviceToken 가져오도록 구현 security 제거

### DIFF
--- a/rento-adapter/build.gradle
+++ b/rento-adapter/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
 
     // Security
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // https://mvnrepository.com/artifact/org.springframework/spring-jdbc
     implementation 'org.springframework:spring-jdbc:6.2.7'

--- a/rento-adapter/src/main/java/com/kbe5/adapter/controller/EventController.java
+++ b/rento-adapter/src/main/java/com/kbe5/adapter/controller/EventController.java
@@ -6,10 +6,12 @@ import com.kbe5.adapter.dto.request.geofence.GeofenceEventRequest;
 import com.kbe5.adapter.dto.request.onoff.OffEventRequest;
 import com.kbe5.adapter.dto.request.onoff.OnEventRequest;
 import com.kbe5.adapter.dto.response.EventResponse;
+import com.kbe5.adapter.service.DeviceTokenService;
 import com.kbe5.common.exception.DeviceResultCode;
 import com.kbe5.domain.commonservice.DriveService;
 import com.kbe5.domain.commonservice.firebase.service.FcmService;
 import com.kbe5.domain.device.entity.DeviceToken;
+import com.kbe5.domain.drive.entity.Drive;
 import com.kbe5.domain.event.entity.CycleEvent;
 import com.kbe5.domain.event.entity.CycleInfo;
 import com.kbe5.domain.event.entity.GeofenceEvent;
@@ -17,10 +19,10 @@ import com.kbe5.domain.event.entity.OnOffEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,20 +37,21 @@ public class EventController {
     private final EventSender eventSender;
     private final DriveService driveService;
     private final FcmService fcmService;
+    private final DeviceTokenService deviceTokenService;
 
     @PostMapping("/on-off/on")
     public ResponseEntity<EventResponse> ignitionOn(
-        @AuthenticationPrincipal DeviceToken deviceToken,
+        @RequestHeader("X-Device-Token") String token,
         @RequestBody @Validated OnEventRequest request
     ){
-
+        DeviceToken deviceToken = deviceTokenService.findDeviceToken(token);
         Long mdn = request.mdn();
 
         driveService.driveStart(deviceToken.getDriveId());
 
         //todo:이부분 성능문제 해결필요
-//        Drive drive = driveService.getDriveDetail(deviceToken.getDriveId());
-//        fcmService.getDrive(drive);
+        Drive drive = driveService.getDriveDetail(deviceToken.getDriveId());
+        fcmService.getDrive(drive);
 
         OnOffEvent onOffEvent = request.toEntity(deviceToken);
         eventSender.send(onOffEvent, mdn);
@@ -58,9 +61,10 @@ public class EventController {
 
     @PostMapping("/on-off/off")
     public ResponseEntity<EventResponse> ignitionOff(
-        @AuthenticationPrincipal DeviceToken deviceToken,
+        @RequestHeader("X-Device-Token") String token,
         @RequestBody @Validated OffEventRequest request) {
 
+        DeviceToken deviceToken = deviceTokenService.findDeviceToken(token);
         Long mdn = request.mdn();
 
         driveService.driveEnd(deviceToken.getDriveId(), request.currentAccumulatedDistance());
@@ -78,10 +82,10 @@ public class EventController {
 
     @PostMapping("/cycle-info")
     public ResponseEntity<EventResponse> emitCycleInfo(
-        @AuthenticationPrincipal DeviceToken deviceToken,
+        @RequestHeader("X-Device-Token") String token,
         @RequestBody @Validated CycleEventRequest request
     ) {
-
+        DeviceToken deviceToken = deviceTokenService.findDeviceToken(token);
         Long mdn = request.mdn();
 
         List<CycleInfo> cycleInfos = request.toCycleInfoEntities(deviceToken);
@@ -94,8 +98,9 @@ public class EventController {
 
     @PostMapping("/geofences")
     public ResponseEntity<EventResponse> receiveGeofenceEvent (
-        @AuthenticationPrincipal DeviceToken deviceToken,
+        @RequestHeader("X-Device-Token") String token,
         @RequestBody @Validated GeofenceEventRequest request) {
+        DeviceToken deviceToken = deviceTokenService.findDeviceToken(token);
 
         GeofenceEvent geofenceEvent = request.toEntity(deviceToken.getDriveId());
         eventSender.send(geofenceEvent, request.mdn());

--- a/rento-adapter/src/main/java/com/kbe5/adapter/service/DeviceTokenService.java
+++ b/rento-adapter/src/main/java/com/kbe5/adapter/service/DeviceTokenService.java
@@ -1,0 +1,20 @@
+package com.kbe5.adapter.service;
+
+import com.kbe5.common.exception.DeviceException;
+import com.kbe5.common.exception.DeviceResultCode;
+import com.kbe5.domain.device.entity.DeviceToken;
+import com.kbe5.domain.device.repository.DeviceTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public DeviceToken findDeviceToken(String deviceToken) {
+        return deviceTokenRepository.findById(deviceToken)
+            .orElseThrow(() -> new DeviceException(DeviceResultCode.INVALID_TOKEN));
+    }
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #150 

---

### 🚀 어떤 기능을 구현했나요 ?
- @RequestHeader 를 사용해서 토큰을 가져오도록 구현하였습니다.

### 🔥 어떤 문제를 마주했나요 ?
- Spirng Security가 없어지면서 DeviceToken 객체를 @AuthenticationPrincipal 을 사용하지 못하는 문제가 발생하였습니다.
- 따라서 @RequestHeader 를 통해 토큰을 가져오고 DB에서 토큰을 조회하는 로직을 구현하였습니다.

### ✨ 어떻게 해결했나요 ?
- @RequestHeader 를 통해서 String token 을 가져와서 DB에서 조회하도록 로직 변경

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 필요한 예외처리 + 토큰 저장소를 Redis로 변경하는 것에 대해서 어떻게 생각하시는지 

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
