### PR TITLE
로그아웃 시 리프레시 삭제 구현

### DIFF
--- a/common/src/main/java/com/kbe5/common/exception/ErrorType.java
+++ b/common/src/main/java/com/kbe5/common/exception/ErrorType.java
@@ -32,7 +32,8 @@ public enum ErrorType {
 
     // SECURITY
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 없거나 잘못된 형식입니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    EXPIRED_TOKEN_ACCESS(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
+    EXPIRED_TOKEN_REFRESH(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
     FAILED_LOGIN(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),
 
@@ -47,13 +48,18 @@ public enum ErrorType {
 
     // Geofence
     GEOFENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "지오펜스를 찾을 수 없습니다."),
+
     //FCM
     FCM_FAILED(HttpStatus.BAD_REQUEST, "FCM 알림 전송에 실패하였습니다"),
     CYCLEINFO_NOT_FOUND(HttpStatus.NOT_FOUND, "주기 정보가 없습니다."),
+
     // Date
     NULL_LOCAL_DATE_TIME(HttpStatus.BAD_REQUEST, "LocalDateTime 값이 null 입니다."),
     BLANK_DATE_STRING(HttpStatus.BAD_REQUEST, "시간 문자열이 비어있거나 null 입니다."),
-    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않는 날짜 형식입니다.");
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않는 날짜 형식입니다."),
+
+    // Redis
+    FAILED_DELETE_FROM_REDIS(HttpStatus.INTERNAL_SERVER_ERROR, "로그아웃 처리 중 서버 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/rento-api/src/main/java/com/kbe5/api/domain/jwt/util/JwtFilter.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/jwt/util/JwtFilter.java
@@ -39,7 +39,7 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
         if (jwtUtil.isExpired(accessToken)) {
-            ErrorResponse.SendError(response, ErrorType.EXPIRED_TOKEN);
+            ErrorResponse.SendError(response, ErrorType.EXPIRED_TOKEN_ACCESS);
             return;
         }
 

--- a/rento-api/src/main/java/com/kbe5/api/domain/jwt/util/JwtUtil.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/jwt/util/JwtUtil.java
@@ -3,6 +3,7 @@ package com.kbe5.api.domain.jwt.util;
 import com.kbe5.api.domain.jwt.dto.JwtManagerArgumentDto;
 import com.kbe5.common.exception.DomainException;
 import com.kbe5.common.exception.ErrorType;
+import com.kbe5.common.response.error.ErrorResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -126,8 +127,7 @@ public class JwtUtil {
         }
 
         if (isExpired(refresh) || !redisTemplate.hasKey(managerArgumentDto.uuid())) {
-            //Todo: 로그아웃 로직 구현
-            throw new DomainException(ErrorType.EXPIRED_TOKEN);
+            throw new DomainException(ErrorType.EXPIRED_TOKEN_REFRESH);
         }
 
         if (!getRefreshFromRedis(managerArgumentDto.uuid()).equals(refresh)) {


### PR DESCRIPTION
로그아웃 시 리프레시 삭제 구현

- resolves #156 

---

### 🚀 어떤 기능을 구현했나요 ?
- 매니저 로그아웃 할 때 리프레시 토큰을 레디스에서 삭제해주는 로직을 구현했습니다.
- 토큰 만료 시 만료된 토큰이 엑세스 와 리프레시를 구분하여 내려줄 수 있게 에러타입을 수정했습니다.

### 🔥 어떤 문제를 마주했나요 ?
- 현재 에러타입이 메시지 밖에 없어서 프로트에서 해당 메시지만을 보고 분기 처리를 해야해서 추 후에 Detail필드를 만들어 프론트에서 바로 처리하게 편하도록 수정을 해야 할 것 같습니다.

### ✨ 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
