### PR TITLE
fix: deploy 환경 로그백 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,7 @@ jobs:
               --network mynet \
               -p 8080:8080 \
               -v /home/ubuntu/firebase:/app/firebase \
+              -v /home/ubuntu/log/api:/app/log/api \
               -e SPRING_PROFILES_ACTIVE=deploy \
               -e FIREBASE_PATH="/app/firebase/rento-firebase.json" \
               -e DB_HOST="\$DB_HOST" -e DB_PORT="\$DB_PORT" \
@@ -102,6 +103,7 @@ jobs:
               --network mynet \
               -p 8081:8081 \
               -v /home/ubuntu/firebase:/app/firebase \
+              -v /home/ubuntu/log/adapter:/app/log/adapter \
               -e SPRING_PROFILES_ACTIVE=deploy \
               -e FIREBASE_PATH="/app/firebase/rento-firebase.json" \
               -e DB_HOST="\$DB_HOST" -e DB_PORT="\$DB_PORT" \

--- a/rento-adapter/src/main/resources/logback-spring.xml
+++ b/rento-adapter/src/main/resources/logback-spring.xml
@@ -9,20 +9,17 @@
     <springProfile name="local">
         <!--console info 이상 -->
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>INFO</level>
-            </filter>
             <encoder>
                 <pattern>${CONSOLE_LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 
-        <!--file warn 이상-->
-        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./log/adapter/app.log</file>
+        <!-- WARN레벨 appender-->
+        <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/adapter/external-warn.log</file>
             <append>true</append>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>./log/adapter/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <fileNamePattern>./log/adapter/external-warn.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
                 <maxFileSize>25MB</maxFileSize>
                 <maxHistory>30</maxHistory>
             </rollingPolicy>
@@ -34,44 +31,84 @@
             </encoder>
         </appender>
 
+        <!-- TRACE레벨 appender (오직 com.kbe5 전용) -->
+        <appender name="FILE_TRACE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/adapter/app-trace.log</file>
+            <append>true</append>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./log/adapter/app-trace.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>25MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="com.kbe5" level="TRACE" additivity="false">
+            <appender-ref ref="FILE_TRACE"/>
+        </logger>
+
+        <root level="WARN">
+            <appender-ref ref="FILE_WARN"/>
+        </root>
+
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
         </root>
+
     </springProfile>
 
     <!--배포 프로파일-->
     <springProfile name="deploy">
         <!--console info 이상 -->
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>WARN</level>
-            </filter>
             <encoder>
                 <pattern>${CONSOLE_LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 
-        <!--file warn 이상-->
-        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./log/adapter/app.log</file>
+        <!-- WARN레벨 appender-->
+        <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/adapter/external-warn.log</file>
             <append>true</append>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>./log/adapter/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <fileNamePattern>./log/adapter/external-warn.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
                 <maxFileSize>25MB</maxFileSize>
                 <maxHistory>30</maxHistory>
             </rollingPolicy>
             <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>TRACE</level>
+                <level>WARN</level>
             </filter>
             <encoder>
                 <pattern>${FILE_LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 
-        <root level="TRACE">
+        <!-- TRACE레벨 appender (오직 com.kbe5 전용) -->
+        <appender name="FILE_TRACE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/adapter/app-trace.log</file>
+            <append>true</append>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./log/adapter/app-trace.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>25MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="com.kbe5" level="TRACE" additivity="false">
+            <appender-ref ref="FILE_TRACE"/>
+        </logger>
+
+        <root level="WARN">
+            <appender-ref ref="FILE_WARN"/>
+        </root>
+
+        <root level="WARN">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
         </root>
 
     </springProfile>

--- a/rento-adapter/src/main/resources/logback-spring.xml
+++ b/rento-adapter/src/main/resources/logback-spring.xml
@@ -3,38 +3,77 @@
 
     <property name="CONSOLE_LOG_PATTERN" value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%5level) %cyan(%logger) - %msg%n" />
     <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n" />
+    <property name="FILE_NAME_PATTERN" value="./log/adapter/%d{yyyy-MM-dd}.%i.log" />
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <encoder>
-            <pattern>${FILE_LOG_PATTERN}</pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/adapter/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>10KB</maxFileSize>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-    </appender>
-
-
+    <!--로컬 프로파일 -->
     <springProfile name="local">
-        <logger name="com.kbe5.api" level="DEBUG" />
+        <!--console info 이상 -->
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>INFO</level>
+            </filter>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <!--file warn 이상-->
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/adapter/app.log</file>
+            <append>true</append>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./log/adapter/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>25MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>WARN</level>
+            </filter>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
         <root level="INFO">
-            <appender-ref ref="CONSOLE" />
-            <appender-ref ref="FILE" />
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
         </root>
     </springProfile>
 
+    <!--배포 프로파일-->
     <springProfile name="deploy">
-        <root level="ERROR">
-            <appender-ref ref="CONSOLE" />
-            <appender-ref ref="FILE" />
+        <!--console info 이상 -->
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>WARN</level>
+            </filter>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <!--file warn 이상-->
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/adapter/app.log</file>
+            <append>true</append>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./log/adapter/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>25MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>TRACE</level>
+            </filter>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <root level="TRACE">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
         </root>
+
     </springProfile>
 
 </configuration>

--- a/rento-api/src/main/resources/logback-spring.xml
+++ b/rento-api/src/main/resources/logback-spring.xml
@@ -9,20 +9,17 @@
     <springProfile name="local">
         <!--console info 이상 -->
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>INFO</level>
-            </filter>
             <encoder>
                 <pattern>${CONSOLE_LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 
-        <!--file warn 이상-->
-        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./log/api/app.log</file>
+        <!-- WARN레벨 appender-->
+        <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/api/external-warn.log</file>
             <append>true</append>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>./log/api/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <fileNamePattern>./log/api/external-warn.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
                 <maxFileSize>25MB</maxFileSize>
                 <maxHistory>30</maxHistory>
             </rollingPolicy>
@@ -34,44 +31,84 @@
             </encoder>
         </appender>
 
+        <!-- TRACE레벨 appender (오직 com.kbe5 전용) -->
+        <appender name="FILE_TRACE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/api/app-trace.log</file>
+            <append>true</append>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./log/api/app-trace.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>25MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="com.kbe5" level="TRACE" additivity="false">
+            <appender-ref ref="FILE_TRACE"/>
+        </logger>
+
+        <root level="WARN">
+            <appender-ref ref="FILE_WARN"/>
+        </root>
+
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
         </root>
+
     </springProfile>
 
     <!--배포 프로파일-->
     <springProfile name="deploy">
         <!--console info 이상 -->
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>WARN</level>
-            </filter>
             <encoder>
                 <pattern>${CONSOLE_LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 
-        <!--file warn 이상-->
-        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./log/api/app.log</file>
+        <!-- WARN레벨 appender-->
+        <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/api/external-warn.log</file>
             <append>true</append>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>./log/api/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <fileNamePattern>./log/api/external-warn.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
                 <maxFileSize>25MB</maxFileSize>
                 <maxHistory>30</maxHistory>
             </rollingPolicy>
             <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>TRACE</level>
+                <level>WARN</level>
             </filter>
             <encoder>
                 <pattern>${FILE_LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 
-        <root level="TRACE">
+        <!-- TRACE레벨 appender (오직 com.kbe5 전용) -->
+        <appender name="FILE_TRACE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/api/app-trace.log</file>
+            <append>true</append>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./log/api/app-trace.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>25MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="com.kbe5" level="TRACE" additivity="false">
+            <appender-ref ref="FILE_TRACE"/>
+        </logger>
+
+        <root level="WARN">
+            <appender-ref ref="FILE_WARN"/>
+        </root>
+
+        <root level="WARN">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
         </root>
 
     </springProfile>

--- a/rento-api/src/main/resources/logback-spring.xml
+++ b/rento-api/src/main/resources/logback-spring.xml
@@ -3,38 +3,77 @@
 
     <property name="CONSOLE_LOG_PATTERN" value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%5level) %cyan(%logger) - %msg%n" />
     <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n" />
+    <property name="FILE_NAME_PATTERN" value="./log/api/%d{yyyy-MM-dd}.%i.log" />
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <encoder>
-            <pattern>${FILE_LOG_PATTERN}</pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/api/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>10KB</maxFileSize>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-    </appender>
-
-
+    <!--로컬 프로파일 -->
     <springProfile name="local">
-        <logger name="com.kbe5.api" level="DEBUG" />
+        <!--console info 이상 -->
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>INFO</level>
+            </filter>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <!--file warn 이상-->
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/api/app.log</file>
+            <append>true</append>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./log/api/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>25MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>WARN</level>
+            </filter>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
         <root level="INFO">
-            <appender-ref ref="CONSOLE" />
-            <appender-ref ref="FILE" />
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
         </root>
     </springProfile>
 
+    <!--배포 프로파일-->
     <springProfile name="deploy">
-        <root level="ERROR">
-            <appender-ref ref="CONSOLE" />
-            <appender-ref ref="FILE" />
+        <!--console info 이상 -->
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>WARN</level>
+            </filter>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <!--file warn 이상-->
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./log/api/app.log</file>
+            <append>true</append>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./log/api/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>25MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>TRACE</level>
+            </filter>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <root level="TRACE">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
         </root>
+
     </springProfile>
 
 </configuration>


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #146 

---

### 🚀 어떤 기능을 구현했나요 ?
- 배포 환경에서 로그백 파일을 남기는 기능을 구현
- 로그 파일이 25MB 초과시 다음 파일로 저장하는 기능
- com.kbe5 하위에서 발생하는 로그는 trace레벨로 설정하여 병목 혹은 누락 현상 모니터링에 사용하도록 하였습니다
- 그외 외부 라이브러리 등은 warn이상 레벨로 설정하여 로그파일 용량이 커지지 않게 하였습니다

### 🔥 어떤 문제를 마주했나요 ?
- 앱을 첫번째실행시에는 로그파일이 생성이 안되고 두번째 실행때 첫번째 로그와 함께 파일을 생성하는 문제

### ✨ 어떻게 해결했나요 ?
- 첫번째 실행시 로그를 버퍼에 저장하지 않고 초기생성파일로 저장하고 그 후에 로그는 이어서 같은 파일에 저장하도록 하였습니다

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 엘라스틱서치, 스케줄링을 이용해 로그백을 고도화해보겠습니다

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
