### PR TITLE
[BE] 사용자/부서 validation 추가 및 validation 예외 수정, 회사 별로 사용자 등록 가능

### DIFF
--- a/common/src/main/java/com/kbe5/common/exception/ExceptionController.java
+++ b/common/src/main/java/com/kbe5/common/exception/ExceptionController.java
@@ -1,6 +1,7 @@
 package com.kbe5.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -27,9 +28,15 @@ public class ExceptionController {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
-        log.warn("ValidationException: {}", e.getMessage());
+        // 첫 번째 필드 에러 메시지를 꺼냄
+        String errorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .findFirst()
+                .orElse(ErrorType.VALIDATION_ERROR.getMessage()); // 기본 메시지
 
-        return ResponseEntity.badRequest().body(new ExceptionResponse(ErrorType.VALIDATION_ERROR.getMessage()));
+        return ResponseEntity.badRequest().body(new ExceptionResponse(errorMessage));
 
     }
 

--- a/domain/src/main/java/com/kbe5/domain/member/repository/MemberRepository.java
+++ b/domain/src/main/java/com/kbe5/domain/member/repository/MemberRepository.java
@@ -29,15 +29,15 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             @Param("search") String search,
             Pageable pageable);
 
-    boolean existsByLoginId(String loginId);
-
-    boolean existsByEmail(String email);
-
-    boolean existsByPhoneNumber(String phoneNumber);
-
     boolean existsByEmailAndIdNot(String email, Long memberId);
 
     boolean existsByLoginIdAndIdNot(String loginId, Long memberId);
 
     boolean existsByPhoneNumberAndIdNot(String phoneNumber, Long memberId);
+
+    boolean existsByCompanyCodeAndLoginId(String companyCode, String loginId);
+
+    boolean existsByCompanyCodeAndEmail(String companyCode, String email);
+
+    boolean existsByCompanyCodeAndPhoneNumber(String companyCode, String phoneNumber);
 }

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 
     implementation("com.google.firebase:firebase-admin:9.2.0")
 
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/infra/src/main/java/com/kbe5/infra/firebase/dto/UpdateFcmTokenRequest.java
+++ b/infra/src/main/java/com/kbe5/infra/firebase/dto/UpdateFcmTokenRequest.java
@@ -1,6 +1,9 @@
 package com.kbe5.infra.firebase.dto;
 
+import jakarta.validation.constraints.*;
+
 public record UpdateFcmTokenRequest(
+        @NotBlank(message = "fcm 토큰값이 존재하지 않습니다.")
         String token
 ) {
 }

--- a/rento-adapter/src/main/resources/application-deploy.yml
+++ b/rento-adapter/src/main/resources/application-deploy.yml
@@ -5,6 +5,8 @@ logging:
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 
 spring:
+  jackson:
+    time-zone: Asia/Seoul
   config:
     activate:
       on-profile: deploy

--- a/rento-api/src/main/java/com/kbe5/api/domain/department/dto/request/DepartmentRegisterRequest.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/department/dto/request/DepartmentRegisterRequest.java
@@ -3,11 +3,13 @@ package com.kbe5.api.domain.department.dto.request;
 import com.kbe5.domain.company.entity.Company;
 import com.kbe5.domain.department.entity.Department;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record DepartmentRegisterRequest(
         @NotBlank(message = "기업코드는 필수입니다.")
         String companyCode,
         @NotBlank(message = "부서이름은 필수입니다.")
+        @Size(max = 10, message = "부서이름은 10자 이내여야 합니다.")
         String departmentName
 ) {
         public static Department of(DepartmentRegisterRequest departmentRegisterRequest, Company company) {

--- a/rento-api/src/main/java/com/kbe5/api/domain/department/dto/request/DepartmentUpdateRequest.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/department/dto/request/DepartmentUpdateRequest.java
@@ -1,11 +1,13 @@
 package com.kbe5.api.domain.department.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record DepartmentUpdateRequest(
         @NotBlank(message = "기업코드는 필수입니다.")
         String companyCode,
         @NotBlank(message = "부서이름은 필수입니다.")
+        @Size(max = 10, message = "부서이름은 10자 이내여야 합니다.")
         String departmentName
 ) {
 }

--- a/rento-api/src/main/java/com/kbe5/api/domain/member/controller/MemberController.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/member/controller/MemberController.java
@@ -59,15 +59,15 @@ public interface MemberController {
     //아이디 중복 체크
     @Operation(summary = "아이디 중복 체크", description = "회원 등록/수정 시 아이디 중복체크를 합니다.")
     @Parameter(name = "loginId", description = "중복 검사할 아이디입니다.", example = "test")
-    ResponseEntity<ApiResponse<Boolean>> checkId(String loginId);
+    ResponseEntity<ApiResponse<Boolean>> checkId(CustomManagerDetails customManagerDetails, String loginId);
 
     //이메일 중복 체크
     @Operation(summary = "이메일 중복 체크", description = "회원 등록/수정 시 이메일 중복체크를 합니다.")
     @Parameter(name = "email", description = "중복 검사할 이메일입니다.", example = "test@test.com")
-    ResponseEntity<ApiResponse<Boolean>> checkEmail(String email);
+    ResponseEntity<ApiResponse<Boolean>> checkEmail(CustomManagerDetails customManagerDetails, String email);
 
     //전화번호 충복 체크
     @Operation(summary = "전화번호 중복 체크", description = "회원 등록/수정 시 전화번호 중복체크를 합니다.")
     @Parameter(name = "phoneNumber", description = "중복 검사할 전화번호입니다", example = "010-1234-5678")
-    ResponseEntity<ApiResponse<Boolean>> checkPhoneNumber(String phoneNumber);
+    ResponseEntity<ApiResponse<Boolean>> checkPhoneNumber(CustomManagerDetails customManagerDetails, String phoneNumber);
 }

--- a/rento-api/src/main/java/com/kbe5/api/domain/member/controller/MemberControllerImpl.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/member/controller/MemberControllerImpl.java
@@ -99,19 +99,30 @@ public class MemberControllerImpl implements MemberController {
     //아이디 중복 체크
     @GetMapping("/check-id/{loginId}")
     public ResponseEntity<ApiResponse<Boolean>> checkId(
+            @AuthenticationPrincipal CustomManagerDetails customManagerDetails,
             @PathVariable String loginId) {
-        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistLoginId(loginId));
+        String companyCode = customManagerDetails.getManager().getCompanyCode();
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistLoginId(companyCode, loginId));
     }
 
     //이메일 중복 체크
     @GetMapping("/check-email/{email}")
-    public ResponseEntity<ApiResponse<Boolean>> checkEmail(@PathVariable String email) {
-        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistEmail(email));
+    public ResponseEntity<ApiResponse<Boolean>> checkEmail(
+            @AuthenticationPrincipal CustomManagerDetails customManagerDetails,
+            @PathVariable String email) {
+        String companyCode = customManagerDetails.getManager().getCompanyCode();
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistEmail(companyCode, email));
     }
 
     //전화번호 중복 체크
     @GetMapping("/check-phone/{phoneNumber}")
-    public ResponseEntity<ApiResponse<Boolean>> checkPhoneNumber(@PathVariable String phoneNumber) {
-        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistPhoneNumber(phoneNumber));
+    public ResponseEntity<ApiResponse<Boolean>> checkPhoneNumber(
+            @AuthenticationPrincipal CustomManagerDetails customManagerDetails,
+            @PathVariable String phoneNumber) {
+        String companyCode = customManagerDetails.getManager().getCompanyCode();
+
+        return ResEntityFactory.toResponse(ApiResultCode.SUCCESS, !memberService.isExistPhoneNumber(companyCode, phoneNumber));
     }
 }

--- a/rento-api/src/main/java/com/kbe5/api/domain/member/dto/request/MemberRegisterRequest.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/member/dto/request/MemberRegisterRequest.java
@@ -2,26 +2,38 @@ package com.kbe5.api.domain.member.dto.request;
 
 import com.kbe5.domain.member.entity.Member;
 import com.kbe5.domain.member.entity.Position;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 public record MemberRegisterRequest(
         @NotBlank(message = "이름은 필수 값입니다.")
+        @Size(max = 10, message = "이름은 10자 이내여야 합니다.")
         String name,
+
         @NotBlank(message = "이메일은 필수 값입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
+
         @NotBlank(message = "직책은 필수 값입니다.")
         String position,
+
         @NotBlank(message = "아이디는 필수 값입니다.")
+        @Size(max = 10, message = "아이디는 10자 이내여야 합니다.")
         String loginId,
+
         @NotBlank(message = "비밀번호는 필수 값입니다.")
         @Size(min = 4, message = "비밀번호는 4자리 이상이어야합니다.")
         String password,
+
         @NotBlank(message = "전화번호는 필수 값입니다.")
+        @Pattern(
+                regexp = "^01[016789]-?\\d{3,4}-?\\d{4}$",
+                message = "올바른 전화번호 형식이 아닙니다."
+        )
         String phoneNumber,
+
         @NotNull(message = "부서는 필수 값입니다.")
         Long departmentId,
+
         @NotBlank(message = "기업코드는 필수 값입니다.")
         String companyCode
 ) {

--- a/rento-api/src/main/java/com/kbe5/api/domain/member/dto/request/MemberUpdateRequest.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/member/dto/request/MemberUpdateRequest.java
@@ -1,22 +1,34 @@
 package com.kbe5.api.domain.member.dto.request;
 
 import com.kbe5.domain.member.entity.Position;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 public record MemberUpdateRequest(
         @NotBlank(message = "이름은 필수 값입니다.")
-        String name,
+        @Size(max = 10, message = "이름은 10자 이내여야 합니다.")
+                String name,
+
         @NotBlank(message = "이메일은 필수 값입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
+
         @NotBlank(message = "직책은 필수 값입니다.")
         String position,
+
+        @NotBlank(message = "아이디는 필수 값입니다.")
+        @Size(max = 10, message = "아이디는 10자 이내여야 합니다.")
+        String loginId,
+
+        @NotBlank(message = "전화번호는 필수 값입니다.")
+        @Pattern(
+                regexp = "^01[016789]-?\\d{3,4}-?\\d{4}$",
+                message = "올바른 전화번호 형식이 아닙니다."
+        )
+        String phoneNumber,
+
         @NotNull(message = "부서는 필수 값입니다.")
         Long departmentId,
-        @NotBlank(message = "전화번호는 필수 값입니다.")
-        String phoneNumber,
-        @NotBlank(message = "아이디는 필수 값입니다.")
-        String loginId,
+
         @NotBlank(message = "기업코드는 필수 값입니다.")
         String companyCode
 ) {

--- a/rento-api/src/main/java/com/kbe5/api/domain/member/service/MemberService.java
+++ b/rento-api/src/main/java/com/kbe5/api/domain/member/service/MemberService.java
@@ -6,7 +6,6 @@ import com.kbe5.api.domain.member.dto.response.MemberInfoResponse;
 import com.kbe5.api.domain.member.vo.MemberUpdateVO;
 import com.kbe5.common.exception.DomainException;
 import com.kbe5.common.exception.ErrorType;
-import com.kbe5.domain.company.entity.Company;
 import com.kbe5.domain.company.repository.CompanyRepository;
 import com.kbe5.domain.department.entity.Department;
 import com.kbe5.domain.department.repository.DepartmentRepository;
@@ -47,13 +46,13 @@ public class MemberService {
     }
 
     private void validateDuplicate(Member member) {
-        if (isExistPhoneNumber(member.getPhoneNumber())) {
+        if (isExistPhoneNumber(member.getCompanyCode(), member.getPhoneNumber())) {
             throw new DomainException(ErrorType.DUPLICATE_PHONE_NUMBER);
         }
-        if (isExistEmail(member.getEmail())) {
+        if (isExistEmail(member.getCompanyCode(), member.getEmail())) {
             throw new DomainException(ErrorType.DUPLICATE_EMAIL);
         }
-        if (isExistLoginId(member.getLoginId())) {
+        if (isExistLoginId(member.getCompanyCode(), member.getLoginId())) {
             throw new DomainException(ErrorType.DUPLICATE_LOGIN_ID);
         }
     }
@@ -120,16 +119,15 @@ public class MemberService {
                 .orElseThrow(() -> new DomainException(ErrorType.MEMBER_NOT_FOUND));
     }
 
-    //todo: 기업별로도 확인하기
-    public boolean isExistLoginId(String loginId) {
-        return memberRepository.existsByLoginId(loginId);
+    public boolean isExistLoginId(String companyCode, String loginId) {
+        return memberRepository.existsByCompanyCodeAndLoginId(companyCode, loginId);
     }
 
-    public boolean isExistEmail(String email) {
-        return memberRepository.existsByEmail(email);
+    public boolean isExistEmail(String companyCode, String email) {
+        return memberRepository.existsByCompanyCodeAndEmail(companyCode, email);
     }
 
-    public boolean isExistPhoneNumber(String phoneNumber) {
-        return memberRepository.existsByPhoneNumber(phoneNumber);
+    public boolean isExistPhoneNumber(String companyCode, String phoneNumber) {
+        return memberRepository.existsByCompanyCodeAndPhoneNumber(companyCode, phoneNumber);
     }
 }

--- a/rento-api/src/main/resources/application-deploy.yml
+++ b/rento-api/src/main/resources/application-deploy.yml
@@ -5,6 +5,8 @@ logging:
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 
 spring:
+  jackson:
+    time-zone: Asia/Seoul
   config:
     activate:
       on-profile: deploy


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #198 

---

### 🚀 어떤 기능을 구현했나요 ?
- validation을 추가하였습니다
- 사용자 등록을 할때 회사별로 검증하도록 추가하였습니다! 이제 C1에 test, C2에 test 이런식으로 회사가 다르다면 중복되어도 에러가 뜨지 않습니다!

### 🔥 어떤 문제를 마주했나요 ?
- Validation에 적은 message가 에러메시지로 뜨지 않는 오류가 있었습니다. 

### ✨ 어떻게 해결했나요 ?
- `@ExceptionHandler`에 적은 메서드를 수정하였습니다! 일단 message 명시가 되어있다면 그 값을 내려주고, 적힌게 없다면 `ErrorType`에  적혀있는 `VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "값을 잘못 입력했습니다.")` 이 메시지를 내려주도록 변경하였습니다!


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
